### PR TITLE
fix: resolve zero-value proof failure in tests

### DIFF
--- a/src/bulletproof_aggregated.c
+++ b/src/bulletproof_aggregated.c
@@ -1122,7 +1122,7 @@ static int calculate_commitment_term(
     if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tB, base_scalar)) return 0;
     pts[n_pts++] = &tB;
 
-   /* 2. <vec_l, G> */
+    /* 2. <vec_l, G> */
     if (!scalar_vector_all_zero(vec_l, n)) {
         if (!secp256k1_bulletproof_ipa_msm(ctx, &tG, G_vec, vec_l, n))
             return 0; /* REAL FAILURE */

--- a/src/bulletproof_aggregated.c
+++ b/src/bulletproof_aggregated.c
@@ -1136,7 +1136,15 @@ static int calculate_commitment_term(
         pts[n_pts++] = &tH;
     }
 
-    return secp256k1_ec_pubkey_combine(ctx, out, pts, n_pts);
+    if (n_pts == 1) {
+        *out = *pts[0];
+        return 1;
+    }
+
+    if (!secp256k1_ec_pubkey_combine(ctx, out, pts, n_pts))
+        return 0;
+
+    return 1;
 }
 
 /**

--- a/src/bulletproof_aggregated.c
+++ b/src/bulletproof_aggregated.c
@@ -1091,6 +1091,7 @@ int secp256k1_bulletproof_create_commitment(
 
     return 1;
 }
+
 /* Helper for a vector 0 */
 static int scalar_vector_all_zero(const unsigned char* scalars, size_t n) {
     unsigned char zero[32] = {0};

--- a/tests/test_bulletproof_agg.c
+++ b/tests/test_bulletproof_agg.c
@@ -6,184 +6,134 @@
 #include "secp256k1_mpt.h"
 #include "test_utils.h"
 
-/* ---- Aggregation parameters ---- */
-#define M 2
 #define BP_VALUE_BITS 64
 #define BP_TOTAL_BITS(m) ((size_t)(BP_VALUE_BITS * (m)))
-
-/* ---- Benchmark parameters ---- */
 #define VERIFY_RUNS 5
 
-
 /* ---- Helpers ---- */
-
 static inline double elapsed_ms(struct timespec a, struct timespec b) {
     return (b.tv_sec - a.tv_sec) * 1000.0 +
            (b.tv_nsec - a.tv_nsec) / 1e6;
 }
 
-/* ---- Main ---- */
-int main(void) {
-    printf("[TEST] Aggregated Bulletproof test (m = %d)\n", M);
+/* ---- Core Test Logic ---- */
+void run_test_case(secp256k1_context* ctx, const char* name, uint64_t* values, size_t m, int run_benchmarks) {
+    printf("\n[TEST] %s (m = %zu)\n", name, m);
 
-    /* ---- Context ---- */
-    secp256k1_context* ctx =
-            secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
-    EXPECT(ctx != NULL);
-
-    /* ---- Values ---- */
-    uint64_t values[M] = { 5000, 123456 };
-    unsigned char blindings[M][32];
-    secp256k1_pubkey commitments[M];
-
-    /* ---- Context Binding ---- */
+    unsigned char blindings[m][32];
+    secp256k1_pubkey commitments[m];
     unsigned char context_id[32];
     EXPECT(RAND_bytes(context_id, 32) == 1);
 
     secp256k1_pubkey pk_base;
-    /* Use the standard H generator from the library */
     EXPECT(secp256k1_mpt_get_h_generator(ctx, &pk_base));
 
     /* ---- Commitments ---- */
-    for (size_t i = 0; i < M; i++) {
+    for (size_t i = 0; i < m; i++) {
         random_scalar(ctx, blindings[i]);
         EXPECT(secp256k1_bulletproof_create_commitment(
-                ctx,
-                &commitments[i],
-                values[i],
-                blindings[i],
-                &pk_base));
+                ctx, &commitments[i], values[i], blindings[i], &pk_base));
     }
 
     /* ---- Generator vectors ---- */
-    const size_t n = BP_TOTAL_BITS(M);
+    const size_t n = BP_TOTAL_BITS(m);
     secp256k1_pubkey* G_vec = malloc(n * sizeof(secp256k1_pubkey));
     secp256k1_pubkey* H_vec = malloc(n * sizeof(secp256k1_pubkey));
     EXPECT(G_vec && H_vec);
 
-    EXPECT(secp256k1_mpt_get_generator_vector(
-            ctx, G_vec, n, (const unsigned char*)"G", 1));
-    EXPECT(secp256k1_mpt_get_generator_vector(
-            ctx, H_vec, n, (const unsigned char*)"H", 1));
+    EXPECT(secp256k1_mpt_get_generator_vector(ctx, G_vec, n, (const unsigned char*)"G", 1));
+    EXPECT(secp256k1_mpt_get_generator_vector(ctx, H_vec, n, (const unsigned char*)"H", 1));
 
-    /* ---- Prove (timed) ---- */
+    /* ---- Prove ---- */
     unsigned char proof[4096];
     size_t proof_len = sizeof(proof);
-
-    printf("[TEST] Proving aggregated range proof...\n");
 
     struct timespec t_p_start, t_p_end;
     clock_gettime(CLOCK_MONOTONIC, &t_p_start);
 
-    /* Note: We cast the 2D array 'blindings' to flat pointer */
     EXPECT(secp256k1_bulletproof_prove_agg(
-            ctx,
-            proof,
-            &proof_len,
-            values,
-            (const unsigned char*)blindings,
-            M,
-            &pk_base,
-            context_id));
+            ctx, proof, &proof_len, values, (const unsigned char*)blindings, m, &pk_base, context_id));
 
     clock_gettime(CLOCK_MONOTONIC, &t_p_end);
+    printf("  Proof size: %zu bytes\n", proof_len);
+    if (run_benchmarks) printf("  [BENCH] Proving time: %.3f ms\n", elapsed_ms(t_p_start, t_p_end));
 
-    printf("[TEST] Proof size = %zu bytes\n", proof_len);
-    printf("[BENCH] Proving time: %.3f ms\n",
-           elapsed_ms(t_p_start, t_p_end));
-
-    /* ---- Verify (single run, timed) ---- */
-    printf("[TEST] Verifying aggregated proof...\n");
-
+    /* ---- Verify ---- */
     struct timespec t_v_start, t_v_end;
     clock_gettime(CLOCK_MONOTONIC, &t_v_start);
 
     int ok = secp256k1_bulletproof_verify_agg(
-            ctx,
-            G_vec,
-            H_vec,
-            proof,
-            proof_len,
-            commitments,
-            M,
-            &pk_base,
-            context_id);
+            ctx, G_vec, H_vec, proof, proof_len, commitments, m, &pk_base, context_id);
 
     clock_gettime(CLOCK_MONOTONIC, &t_v_end);
-
     EXPECT(ok);
+    printf("  PASSED (Verification)\n");
+    if (run_benchmarks) printf("  [BENCH] Verification time: %.3f ms\n", elapsed_ms(t_v_start, t_v_end));
 
-    printf("PASSED\n");
-    printf("[BENCH] Verification time (single): %.3f ms\n",
-           elapsed_ms(t_v_start, t_v_end));
-
-    /* ---- Verify benchmark (average) ---- */
-    double total_ms = 0.0;
-
-    for (int i = 0; i < VERIFY_RUNS; i++) {
-        struct timespec ts, te;
-        clock_gettime(CLOCK_MONOTONIC, &ts);
-
-        ok = secp256k1_bulletproof_verify_agg(
-                ctx,
-                G_vec,
-                H_vec,
-                proof,
-                proof_len,
-                commitments,
-                M,
-                &pk_base,
-                context_id);
-
-        clock_gettime(CLOCK_MONOTONIC, &te);
-
-        EXPECT(ok);
-        total_ms += elapsed_ms(ts, te);
+    /* ---- Benchmark Verify ---- */
+    if (run_benchmarks) {
+        double total_ms = 0.0;
+        for (int i = 0; i < VERIFY_RUNS; i++) {
+            struct timespec ts, te;
+            clock_gettime(CLOCK_MONOTONIC, &ts);
+            ok = secp256k1_bulletproof_verify_agg(
+                    ctx, G_vec, H_vec, proof, proof_len, commitments, m, &pk_base, context_id);
+            clock_gettime(CLOCK_MONOTONIC, &te);
+            EXPECT(ok);
+            total_ms += elapsed_ms(ts, te);
+        }
+        printf("  [BENCH] Verification avg over %d runs: %.3f ms\n", VERIFY_RUNS, total_ms / VERIFY_RUNS);
     }
 
-    printf("[BENCH] Verification avg over %d runs: %.3f ms\n",
-           VERIFY_RUNS, total_ms / VERIFY_RUNS);
-
-    /* ---- Negative test ---- */
-    printf("[TEST] Tamper test... ");
-
-    secp256k1_pubkey bad_commitments[M];
-    memcpy(bad_commitments, commitments, sizeof(commitments));
-
+    /* ---- Negative Test (Tamper) ---- */
+    secp256k1_pubkey bad_commitments[m];
+    memcpy(bad_commitments, commitments, sizeof(secp256k1_pubkey) * m);
     unsigned char bad_blinding[32];
     random_scalar(ctx, bad_blinding);
 
-    /* Create a fake commitment to (value + 1) to break the sum */
+    /* Create fake commitment to (value + 1) */
     EXPECT(secp256k1_bulletproof_create_commitment(
-            ctx,
-            &bad_commitments[1],
-            values[M - 1] + 1,
-            bad_blinding,
-            &pk_base));
+            ctx, &bad_commitments[m - 1], values[m - 1] + 1, bad_blinding, &pk_base));
 
     ok = secp256k1_bulletproof_verify_agg(
-            ctx,
-            G_vec,
-            H_vec,
-            proof,
-            proof_len,
-            bad_commitments,
-            M,
-            &pk_base,
-            context_id);
+            ctx, G_vec, H_vec, proof, proof_len, bad_commitments, m, &pk_base, context_id);
 
     if (ok) {
         fprintf(stderr, "FAILED: Accepted invalid proof!\n");
         exit(EXIT_FAILURE);
     }
+    printf("  PASSED (Rejected invalid proof)\n");
 
-    printf("PASSED (rejected invalid proof)\n");
-
-    /* ---- Cleanup ---- */
     free(G_vec);
     free(H_vec);
-    secp256k1_context_destroy(ctx);
+}
 
-    printf("[TEST] Aggregated Bulletproof test completed successfully\n");
+/* ---- Main ---- */
+int main(void) {
+    secp256k1_context* ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    EXPECT(ctx != NULL);
+
+    /* 1. Single proof, value 0 (The Bug Fix) */
+    uint64_t v1[] = {0};
+    run_test_case(ctx, "Single Proof (Value 0)", v1, 1, 0);
+
+    /* 2. Single proof, value 1 */
+    uint64_t v2[] = {1};
+    run_test_case(ctx, "Single Proof (Value 1)", v2, 1, 0);
+
+    /* 3. Single proof, MAX VALUE (Tests opposite vector edge case) */
+    uint64_t v3[] = {0xFFFFFFFFFFFFFFFF}; // 2^64 - 1
+    run_test_case(ctx, "Single Proof (MAX Value)", v3, 1, 0);
+
+    /* 4. Aggregated proof, {0, 1} */
+    uint64_t v4[] = {0, 1};
+    run_test_case(ctx, "Aggregated Proof (0, 1)", v4, 2, 0);
+
+    /* 5. Aggregated proof, {0, 0} with Benchmarks */
+    uint64_t v5[] = {0, 0};
+    run_test_case(ctx, "Aggregated Proof (0, 0)", v5, 2, 1);
+
+    secp256k1_context_destroy(ctx);
+    printf("\n[TEST] All Bulletproof tests completed successfully\n");
     return 0;
 }

--- a/tests/test_bulletproof_agg.c
+++ b/tests/test_bulletproof_agg.c
@@ -18,6 +18,7 @@ static inline double elapsed_ms(struct timespec a, struct timespec b) {
 
 /* ---- Core Test Logic ---- */
 void run_test_case(secp256k1_context* ctx, const char* name, uint64_t* values, size_t num_values, int run_benchmarks) {
+    EXPECT(num_values > 0);
     printf("\n[TEST] %s (num_values = %zu)\n", name, num_values);
 
     unsigned char (*blindings)[32] = malloc(num_values * sizeof(*blindings));

--- a/tests/test_bulletproof_agg.c
+++ b/tests/test_bulletproof_agg.c
@@ -129,7 +129,9 @@ void run_test_case(secp256k1_context* ctx, const char* name, uint64_t* values, s
     EXPECT(secp256k1_bulletproof_create_commitment(
             ctx,
             &bad_commitments[num_values - 1],
-            values[num_values - 1] + 1,
+            (values[num_values - 1] == UINT64_MAX)
+            ? values[num_values - 1] - 1
+            : values[num_values - 1] + 1,
             bad_blinding,
             &pk_base));
 


### PR DESCRIPTION
### Description

When a user attempts to prove `value = 0`, the decomposed left bit vector ($\mathbf{a}_L$) is entirely zeros. Similarly, if proving the maximum value (`UINT64_MAX`), the right bit vector ($\mathbf{a}_R$) becomes entirely zeros. When these all-zero vectors are passed to the internal Multi-Scalar Multiplication (`ipa_msm`) function, the mathematical result is the Point at Infinity. Since the `libsecp256k1` library cannot represent infinity in standard affine coordinates, the MSM function correctly returns `0`. Previously, the prover treated this `0` return value as a fatal library error and aborted the proof generation.

**Fix:**
Updated `secp256k1_bulletproof_prove_agg` to handle the `0` return from `ipa_msm`. If the result evaluates to the Point at Infinity, the prover now safely skips adding that empty term to the commitment instead of failing. There are no changes to the underlying math library or external APIs.

### Changes
- Modified the point combination logic for Commitments `A` and `S` in `src/bulletproof_aggregated.c` to safely handle the Point at Infinity.
- Added comprehensive explicit test cases to `tests/test_bulletproof_agg.c`:
  - `m=1, value={0}` (The exact bug reproduction).
  - `m=1, value={UINT64_MAX}` (Tests the opposite boundary condition where the right-side bit vector becomes all zeros).
  - `m=2, values={0, 0}` (Ensures zero-term skipping works correctly across aggregated proofs).
  - `m=1, value={1}` and `m=2, values={0, 1}` (Ensures standard non-zero proofs still pass without regression).