### PR TITLE
refactor: extract protocol size constants into mpt_protocol.h

### DIFF
--- a/include/mpt_protocol.h
+++ b/include/mpt_protocol.h
@@ -1,0 +1,64 @@
+#ifndef MPT_PROTOCOL_H
+#define MPT_PROTOCOL_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// XRPL Transaction Types, the number MUST match rippled's definitions
+#define ttCONFIDENTIAL_MPT_CONVERT 85
+#define ttCONFIDENTIAL_MPT_MERGE_INBOX 86
+#define ttCONFIDENTIAL_MPT_CONVERT_BACK 87
+#define ttCONFIDENTIAL_MPT_SEND 88
+#define ttCONFIDENTIAL_MPT_CLAWBACK 89
+
+// General crypto primitive sizes in bytes
+#define kMPT_HALF_SHA_SIZE 32
+#define kMPT_PUBKEY_SIZE 33
+#define kMPT_PRIVKEY_SIZE 32
+#define kMPT_BLINDING_FACTOR_SIZE 32
+
+// ElGamal & Pedersen primitive sizes in bytes
+#define kMPT_ELGAMAL_CIPHER_SIZE 33
+#define kMPT_ELGAMAL_TOTAL_SIZE 66
+#define kMPT_PEDERSEN_COMMIT_SIZE 33
+
+// Proof sizes in bytes
+#define kMPT_SCHNORR_PROOF_SIZE 64
+#define kMPT_SINGLE_BULLETPROOF_SIZE 688
+#define kMPT_DOUBLE_BULLETPROOF_SIZE 754
+
+// Context hash size
+#define kMPT_ZKP_CONTEXT_HASH_SIZE 74
+
+// Account ID size in bytes
+#define kMPT_ACCOUNT_ID_SIZE 20
+
+// MPTokenIssuance ID size in bytes
+#define kMPT_ISSUANCE_ID_SIZE 24
+
+/**
+ * @brief Represents a unique 24-byte MPT issuance ID.
+ */
+typedef struct
+{
+    uint8_t bytes[kMPT_ISSUANCE_ID_SIZE];
+} mpt_issuance_id;
+
+/**
+ * @brief Represents a 20-byte account ID.
+ *
+ * - bytes: Raw 20-byte array containing the AccountID.
+ */
+typedef struct account_id
+{
+    uint8_t bytes[kMPT_ACCOUNT_ID_SIZE];
+} account_id;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // MPT_PROTOCOL_H

--- a/include/mpt_protocol.h
+++ b/include/mpt_protocol.h
@@ -39,24 +39,6 @@ extern "C" {
 // MPTokenIssuance ID size in bytes
 #define kMPT_ISSUANCE_ID_SIZE 24
 
-/**
- * @brief Represents a unique 24-byte MPT issuance ID.
- */
-typedef struct
-{
-    uint8_t bytes[kMPT_ISSUANCE_ID_SIZE];
-} mpt_issuance_id;
-
-/**
- * @brief Represents a 20-byte account ID.
- *
- * - bytes: Raw 20-byte array containing the AccountID.
- */
-typedef struct account_id
-{
-    uint8_t bytes[kMPT_ACCOUNT_ID_SIZE];
-} account_id;
-
 #ifdef __cplusplus
 }
 #endif

--- a/include/utility/mpt_utility.h
+++ b/include/utility/mpt_utility.h
@@ -1,65 +1,15 @@
 #ifndef MPT_UTILITY_H
 #define MPT_UTILITY_H
 
+#include <mpt_protocol.h>
 #include <secp256k1.h>
 #include <secp256k1_mpt.h>
 #include <stdbool.h>
 #include <stddef.h>
-#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-// XRPL Transaction Types, the number MUST match rippled's definitions
-#define ttCONFIDENTIAL_MPT_CONVERT 85
-#define ttCONFIDENTIAL_MPT_MERGE_INBOX 86
-#define ttCONFIDENTIAL_MPT_CONVERT_BACK 87
-#define ttCONFIDENTIAL_MPT_SEND 88
-#define ttCONFIDENTIAL_MPT_CLAWBACK 89
-
-// General crypto primitive sizes in bytes
-#define kMPT_HALF_SHA_SIZE 32
-#define kMPT_PUBKEY_SIZE 33
-#define kMPT_PRIVKEY_SIZE 32
-#define kMPT_BLINDING_FACTOR_SIZE 32
-
-// Gamal & Pedersen primitive sizes in bytes
-#define kMPT_ELGAMAL_CIPHER_SIZE 33
-#define kMPT_ELGAMAL_TOTAL_SIZE 66
-#define kMPT_PEDERSEN_COMMIT_SIZE 33
-
-// Proof sizes in bytes
-#define kMPT_SCHNORR_PROOF_SIZE 64
-#define kMPT_SINGLE_BULLETPROOF_SIZE 688
-#define kMPT_DOUBLE_BULLETPROOF_SIZE 754
-
-// Context hash size
-#define kMPT_ZKP_CONTEXT_HASH_SIZE 74
-
-// Account ID size in bytes
-#define kMPT_ACCOUNT_ID_SIZE 20
-
-// MPTokenIssuance ID size in bytes
-#define kMPT_ISSUANCE_ID_SIZE 24
-
-/**
- * @brief Represents a unique 24-byte MPT issuance ID.
- */
-typedef struct
-{
-    uint8_t bytes[kMPT_ISSUANCE_ID_SIZE];
-} mpt_issuance_id;
-
-/**
- * @brief Represents a 20-byte account ID.
- *
- * - bytes: Raw 20-byte array containing the AccountID.
- */
-typedef struct account_id
-{
-    uint8_t bytes[kMPT_ACCOUNT_ID_SIZE];
-} account_id;
 
 /**
  * @brief Represents a participant in a Confidential Send transaction.

--- a/include/utility/mpt_utility.h
+++ b/include/utility/mpt_utility.h
@@ -12,6 +12,24 @@ extern "C" {
 #endif
 
 /**
+ * @brief Represents a unique 24-byte MPT issuance ID.
+ */
+typedef struct
+{
+    uint8_t bytes[kMPT_ISSUANCE_ID_SIZE];
+} mpt_issuance_id;
+
+/**
+ * @brief Represents a 20-byte account ID.
+ *
+ * - bytes: Raw 20-byte array containing the AccountID.
+ */
+typedef struct account_id
+{
+    uint8_t bytes[kMPT_ACCOUNT_ID_SIZE];
+} account_id;
+
+/**
  * @brief Represents a participant in a Confidential Send transaction.
  *
  * - pubkey: The 33-byte compressed secp256k1 public key.


### PR DESCRIPTION
## Summary

- Create `include/mpt_protocol.h` with all wire-format size `#define`s, transaction type constants, and pure data structs (`mpt_issuance_id`, `account_id`)
- `mpt_utility.h` now `#include <mpt_protocol.h>` instead of defining these inline
- Lets consumers (e.g. rippled) include protocol sizes without pulling in the full utility API and its secp256k1/OpenSSL dependencies

Per [yinyi's suggestion on PR #24](https://github.com/XRPLF/mpt-crypto/pull/24#discussion_r3067166701).

## Test plan

- [x] Full rebuild, 13/13 tests pass