### PR TITLE
Add workflow to build shared libraries and attach to releases

### DIFF
--- a/.github/scripts/build-shared-lib.sh
+++ b/.github/scripts/build-shared-lib.sh
@@ -1,11 +1,4 @@
 #!/usr/bin/env bash
-# .github/scripts/build-shared-lib.sh
-#
-# Builds libmpt-crypto as a shared library with tests, via Conan + CMake.
-# Invoked by .github/workflows/build-shared-libs.yml — either directly on
-# a GitHub-hosted runner (Linux / macOS / Windows) or inside a
-# --platform linux/<arch> Docker container for platforms without native
-# runners (currently s390x via QEMU user-mode emulation).
 set -euo pipefail
 
 conan profile detect --force

--- a/.github/scripts/build-shared-lib.sh
+++ b/.github/scripts/build-shared-lib.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# .github/scripts/build-shared-lib.sh
+#
+# Builds libmpt-crypto as a shared library with tests, via Conan + CMake.
+# Invoked by .github/workflows/build-shared-libs.yml — either directly on
+# a GitHub-hosted runner (Linux / macOS / Windows) or inside a
+# --platform linux/<arch> Docker container for platforms without native
+# runners (currently s390x via QEMU user-mode emulation).
+#
+# Preconditions: python3, conan, cmake, ninja (and MSVC on Windows) are
+# on PATH, and the cwd is the repo root. RUNNER_OS is read to decide
+# Windows-vs-POSIX behaviour; it's unset inside emulated containers, so
+# we default to Linux.
+set -euo pipefail
+
+conan profile detect --force
+conan remote add --index 0 --force xrplf https://conan.ripplex.io
+
+# fPIC is a POSIX-only concept; MSVC rejects it.
+CONAN_ARGS=(
+  -of build
+  --build=missing
+  -s build_type=Release
+  -o "&:shared=True"
+  -o "&:tests=True"
+  -o "secp256k1/*:shared=False"
+  -o "openssl/*:shared=False"
+)
+if [[ "${RUNNER_OS:-Linux}" != "Windows" ]]; then
+  CONAN_ARGS+=(-o "secp256k1/*:fPIC=True" -o "openssl/*:fPIC=True")
+fi
+conan install . "${CONAN_ARGS[@]}"
+
+# Windows uses the Visual Studio multi-config generator; everything else
+# uses Ninja (single-config, so CMAKE_BUILD_TYPE is baked in here).
+CMAKE_ARGS=(
+  -B build
+  -S .
+  -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake
+)
+if [[ "${RUNNER_OS:-Linux}" == "Windows" ]]; then
+  CMAKE_ARGS+=(
+    -G "Visual Studio 17 2022"
+    -A x64
+    -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
+  )
+else
+  CMAKE_ARGS+=(
+    -G Ninja
+    -DCMAKE_BUILD_TYPE=Release
+  )
+fi
+cmake "${CMAKE_ARGS[@]}"
+
+cmake --build build --config Release
+
+# Windows has no rpath — test executables need the DLL's directory on
+# PATH. With the VS generator the DLL lands at build/Release/, so prepend
+# that. -C Release selects the VS multi-config build.
+pushd build > /dev/null
+CTEST_ARGS=(--output-on-failure)
+if [[ "${RUNNER_OS:-Linux}" == "Windows" ]]; then
+  export PATH="$(pwd)/Release:${PATH}"
+  CTEST_ARGS+=(-C Release)
+fi
+ctest "${CTEST_ARGS[@]}"
+popd > /dev/null

--- a/.github/scripts/build-shared-lib.sh
+++ b/.github/scripts/build-shared-lib.sh
@@ -6,17 +6,11 @@
 # a GitHub-hosted runner (Linux / macOS / Windows) or inside a
 # --platform linux/<arch> Docker container for platforms without native
 # runners (currently s390x via QEMU user-mode emulation).
-#
-# Preconditions: python3, conan, cmake, ninja (and MSVC on Windows) are
-# on PATH, and the cwd is the repo root. RUNNER_OS is read to decide
-# Windows-vs-POSIX behaviour; it's unset inside emulated containers, so
-# we default to Linux.
 set -euo pipefail
 
 conan profile detect --force
 conan remote add --index 0 --force xrplf https://conan.ripplex.io
 
-# fPIC is a POSIX-only concept; MSVC rejects it.
 CONAN_ARGS=(
   -of build
   --build=missing
@@ -31,8 +25,6 @@ if [[ "${RUNNER_OS:-Linux}" != "Windows" ]]; then
 fi
 conan install . "${CONAN_ARGS[@]}"
 
-# Windows uses the Visual Studio multi-config generator; everything else
-# uses Ninja (single-config, so CMAKE_BUILD_TYPE is baked in here).
 CMAKE_ARGS=(
   -B build
   -S .
@@ -54,9 +46,6 @@ cmake "${CMAKE_ARGS[@]}"
 
 cmake --build build --config Release
 
-# Windows has no rpath — test executables need the DLL's directory on
-# PATH. With the VS generator the DLL lands at build/Release/, so prepend
-# that. -C Release selects the VS multi-config build.
 pushd build > /dev/null
 CTEST_ARGS=(--output-on-failure)
 if [[ "${RUNNER_OS:-Linux}" == "Windows" ]]; then

--- a/.github/workflows/build-client-lib-natives.yml
+++ b/.github/workflows/build-client-lib-natives.yml
@@ -1,0 +1,289 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Build Native Binaries for Client Libraries
+#
+# Builds the mpt-crypto C library as a self-contained shared library for each
+# supported platform, producing binaries that client libraries (xrpl4j via JNA,
+# xrpl-py via ctypes, etc.) can load directly at runtime. Dependencies
+# (secp256k1, OpenSSL) are statically linked so the resulting binaries work
+# without any system-level installs on the consumer's machine.
+#
+# Triggers:
+#   - Push of a release tag (e.g. 0.3.0, 0.3.0-rc1)
+#   - Manual workflow_dispatch on any branch / tag / SHA (for testing)
+#
+# The output artifacts follow the JNA platform-naming convention (also
+# compatible with Python ctypes lookups):
+#   darwin-aarch64/libmptcrypto.dylib   (macOS ARM64)
+#   darwin-x86-64/libmptcrypto.dylib    (macOS x86_64)
+#   linux-aarch64/libmptcrypto.so       (Linux ARM64)
+#   linux-x86-64/libmptcrypto.so        (Linux x86_64)
+#   win32-x86-64/mptcrypto.dll          (Windows x86_64)
+# ──────────────────────────────────────────────────────────────────────────────
+
+name: Build Native Binaries for Client Libraries
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build ${{ matrix.platform }}
+    strategy:
+      # Cancel in-flight matrix jobs as soon as any one fails — no point burning
+      # runner minutes on 4 more builds when the release is already broken.
+      fail-fast: false
+      matrix:
+        include:
+          # ── macOS ARM64 (Apple Silicon) ──
+          - os: macos-14
+            platform: darwin-aarch64
+            lib_filename: libmptcrypto.dylib
+            cmake_lib_filename: libmpt-crypto.dylib
+
+          # ── macOS x86_64 (Intel) ──
+          - os: macos-15-intel
+            platform: darwin-x86-64
+            lib_filename: libmptcrypto.dylib
+            cmake_lib_filename: libmpt-crypto.dylib
+
+          # ── Linux ARM64 ──
+          - os: ubuntu-24.04-arm
+            platform: linux-aarch64
+            lib_filename: libmptcrypto.so
+            cmake_lib_filename: libmpt-crypto.so
+
+          # ── Linux x86_64 ──
+          - os: ubuntu-latest
+            platform: linux-x86-64
+            lib_filename: libmptcrypto.so
+            cmake_lib_filename: libmpt-crypto.so
+
+          # ── Windows x86_64 ──
+          - os: windows-latest
+            platform: win32-x86-64
+            lib_filename: mptcrypto.dll
+            cmake_lib_filename: mpt-crypto.dll
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # ── Checkout the ref that triggered this workflow ──
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # ── Set up build tools ──
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Conan and Ninja
+        run: pip install "conan>=2.0.0" ninja
+
+      # Windows needs the MSVC developer environment for cl.exe, link.exe, etc.
+      # NOTE: upstream msvc-dev-cmd is still on Node 20 — no Node 24 release yet.
+      # GitHub's Node 20 deprecation warning is expected here until upstream ships.
+      - name: Set up MSVC environment
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
+
+      # ── Configure Conan ──
+      # Use auto-detected profile so we don't need to hand-craft compiler
+      # settings for each platform. Then add the XRPLF remote where secp256k1
+      # packages are hosted.
+      - name: Configure Conan
+        shell: bash
+        run: |
+          conan profile detect --force
+          echo "==> Detected Conan profile:"
+          conan profile show
+          conan remote add --index 0 xrplf https://conan.ripplex.io || true
+
+      # ── Install dependencies via Conan ──
+      #
+      # Key flags:
+      #   -o "&:shared=True"             → Build mpt-crypto as a SHARED library
+      #   -o "&:tests=False"             → Skip building test executables
+      #   -o "secp256k1/*:shared=False"  → Static secp256k1, linked INTO the shared lib
+      #   -o "openssl/*:shared=False"    → Static OpenSSL, linked INTO the shared lib
+      #   -o "*/fPIC=True"               → Position Independent Code for static deps
+      #                                    (required when linking static libs into a .so/.dylib)
+      #   -b missing                     → Build deps from source if no pre-built binary
+      #
+      # On Windows, fPIC doesn't apply — Conan ignores it for MSVC targets.
+      - name: Install dependencies (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          conan install . \
+            -of build \
+            -b missing \
+            -s build_type=Release \
+            -o "&:shared=True" \
+            -o "&:tests=False" \
+            -o "secp256k1/*:shared=False" \
+            -o "secp256k1/*:fPIC=True" \
+            -o "openssl/*:shared=False" \
+            -o "openssl/*:fPIC=True"
+
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          conan install . \
+            -of build \
+            -b missing \
+            -s build_type=Release \
+            -o "&:shared=True" \
+            -o "&:tests=False" \
+            -o "secp256k1/*:shared=False" \
+            -o "openssl/*:shared=False"
+
+      # ── Configure CMake ──
+      #
+      # The Conan toolchain file (conan_toolchain.cmake) configures:
+      #   - CMAKE_BUILD_TYPE=Release (single-config generators)
+      #   - BUILD_SHARED_LIBS=ON (from shared=True)
+      #   - Find-package paths for secp256k1 and OpenSSL
+      #
+      # Windows uses the VS generator because Ninja doesn't support
+      # CMAKE_GENERATOR_PLATFORM which Conan's MSVC toolchain sets.
+      - name: Configure CMake (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          TOOLCHAIN=$(find build -name "conan_toolchain.cmake" -print -quit)
+          if [ -z "${TOOLCHAIN}" ]; then
+            echo "ERROR: Could not find conan_toolchain.cmake under build/"
+            find build -type f -name "*.cmake" | head -20
+            exit 1
+          fi
+          echo "==> Using toolchain: ${TOOLCHAIN}"
+
+          cmake -B build -S . \
+            -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" \
+            -DCMAKE_BUILD_TYPE=Release
+
+      - name: Configure CMake (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          TOOLCHAIN=$(find build -name "conan_toolchain.cmake" -print -quit)
+          if [ -z "${TOOLCHAIN}" ]; then
+            echo "ERROR: Could not find conan_toolchain.cmake under build/"
+            find build -type f -name "*.cmake" | head -20
+            exit 1
+          fi
+          echo "==> Using toolchain: ${TOOLCHAIN}"
+
+          cmake -B build -S . \
+            -G "Visual Studio 17 2022" \
+            -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" \
+            -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
+
+      # ── Build ──
+      - name: Build shared library
+        shell: bash
+        run: cmake --build build --config Release
+
+      # ── Package ──
+      # CMake produces "mpt-crypto" (with hyphen) as the library name.
+      # We rename to "mptcrypto" (no hyphen) because JNA's Native.load("mptcrypto")
+      # expects this convention.
+      - name: Package library
+        shell: bash
+        run: |
+          mkdir -p output/${{ matrix.platform }}
+
+          BUILT_LIB=$(find build -maxdepth 2 \( \
+            -name "${{ matrix.cmake_lib_filename }}" \
+            \) -print -quit)
+
+          if [ -z "${BUILT_LIB}" ]; then
+            echo "ERROR: Could not find ${{ matrix.cmake_lib_filename }} in build/"
+            echo "Build directory contents:"
+            find build -type f \( -name "*.dylib" -o -name "*.so" -o -name "*.dll" \) 2>/dev/null
+            exit 1
+          fi
+
+          echo "==> Found: ${BUILT_LIB}"
+          cp "${BUILT_LIB}" "output/${{ matrix.platform }}/${{ matrix.lib_filename }}"
+          echo "==> Packaged: output/${{ matrix.platform }}/${{ matrix.lib_filename }}"
+
+      # ── Verify ──
+      # Confirm the library is self-contained: linked libraries should only be
+      # system libs (no secp256k1 or libcrypto as external shared deps).
+      - name: Verify library (macOS)
+        if: startsWith(matrix.platform, 'darwin')
+        run: |
+          echo "==> Linked libraries (should only show system libs):"
+          otool -L output/${{ matrix.platform }}/${{ matrix.lib_filename }}
+          echo ""
+          echo "==> Architecture:"
+          file output/${{ matrix.platform }}/${{ matrix.lib_filename }}
+
+      - name: Verify library (Linux)
+        if: startsWith(matrix.platform, 'linux')
+        run: |
+          echo "==> Linked libraries (should only show system libs):"
+          ldd output/${{ matrix.platform }}/${{ matrix.lib_filename }} || true
+          echo ""
+          echo "==> Architecture:"
+          file output/${{ matrix.platform }}/${{ matrix.lib_filename }}
+
+      - name: Verify library (Windows)
+        if: startsWith(matrix.platform, 'win32')
+        shell: bash
+        run: |
+          echo "==> File info:"
+          file output/${{ matrix.platform }}/${{ matrix.lib_filename }}
+
+      # ── Upload per-platform artifact ──
+      # Upload output/ (not output/<platform>/) so the platform subdirectory
+      # is preserved inside the artifact. This ensures merge-multiple in the
+      # bundle job doesn't overwrite files with the same name across platforms.
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mptcrypto-${{ matrix.platform }}
+          path: output/
+          if-no-files-found: error
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Bundle all platform artifacts into a single downloadable archive.
+  # The structure matches what JNA expects on the classpath:
+  #   darwin-aarch64/libmptcrypto.dylib
+  #   darwin-x86-64/libmptcrypto.dylib
+  #   linux-aarch64/libmptcrypto.so
+  #   linux-x86-64/libmptcrypto.so
+  #   win32-x86-64/mptcrypto.dll
+  # ──────────────────────────────────────────────────────────────────────────
+  bundle:
+    name: Bundle all native libraries
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all platform artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: mptcrypto-*
+          path: natives/
+          merge-multiple: true
+
+      - name: Display bundled structure
+        run: |
+          echo "==> Bundled native libraries:"
+          find natives/ -type f | sort
+          echo ""
+          echo "==> File sizes:"
+          find natives/ -type f -exec ls -lh {} \;
+
+      - name: Upload combined artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mptcrypto-all-platforms
+          path: natives/
+          if-no-files-found: error

--- a/.github/workflows/build-client-lib-natives.yml
+++ b/.github/workflows/build-client-lib-natives.yml
@@ -30,6 +30,11 @@ name: Build Native Binaries for Client Libraries
 on:
   workflow_dispatch:
 
+# Default to read-only; the bundle job escalates to contents: write so it can
+# attach assets to the release via `gh release upload`.
+permissions:
+  contents: read
+
 jobs:
   # ──────────────────────────────────────────────────────────────────────────
   # Gate: only proceed when dispatched from a tag ref that already has a
@@ -298,6 +303,8 @@ jobs:
     name: Bundle and attach to release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Download all platform artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/build-client-lib-natives.yml
+++ b/.github/workflows/build-client-lib-natives.yml
@@ -8,9 +8,11 @@
 # without any system-level installs on the consumer's machine.
 #
 # Triggers:
-#   - workflow_dispatch ONLY, and the selected ref MUST be a tag that already
-#     has a published GitHub release (release notes generated). The guard job
-#     below enforces both preconditions and fails fast otherwise.
+#   - workflow_dispatch ONLY. Dispatch from the branch that hosts this YAML
+#     (so the workflow definition is picked up), and pass the release `tag`
+#     as an input. The guard job below fails fast unless a GitHub release
+#     already exists for that tag (release notes generated). The build jobs
+#     check out the tag — so the YAML ref and the built source are decoupled.
 #
 # The output artifacts follow the JNA platform-naming convention (also
 # compatible with Python ctypes lookups):
@@ -20,15 +22,20 @@
 #   linux-x86-64/libmptcrypto.so        (Linux x86_64)
 #   win32-x86-64/mptcrypto.dll          (Windows x86_64)
 #
-# Binaries are attached to the existing GitHub release as assets (per-platform
-# tarballs + a combined bundle). Re-running on the same tag overwrites the
-# previously-uploaded assets of the same name via `gh release upload --clobber`.
+# A single combined archive (mptcrypto-natives-<tag>.tar.gz) is attached to
+# the release. Re-running on the same tag overwrites the previously-uploaded
+# asset via `gh release upload --clobber`.
 # ──────────────────────────────────────────────────────────────────────────────
 
 name: Build Native Binaries for Client Libraries
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to build and attach binaries to (must already have a published GitHub release)"
+        required: true
+        type: string
 
 # Default to read-only; the bundle job escalates to contents: write so it can
 # attach assets to the release via `gh release upload`.
@@ -37,34 +44,37 @@ permissions:
 
 jobs:
   # ──────────────────────────────────────────────────────────────────────────
-  # Gate: only proceed when dispatched from a tag ref that already has a
-  # published GitHub release. workflow_dispatch lets users pick any
-  # branch/tag/SHA from the UI, so we enforce both preconditions explicitly.
+  # Gate: verify the `tag` input points at a real tag with a published
+  # GitHub release. The workflow YAML is loaded from whatever branch the
+  # user dispatched from (typically the branch hosting this file); the tag
+  # identifies what source gets built and where assets get attached.
   # ──────────────────────────────────────────────────────────────────────────
   guard:
     name: Verify tag + release exist
     runs-on: ubuntu-latest
     steps:
-      - name: Require tag ref
+      - name: Require tag exists in repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
-            echo "ERROR: This workflow must be dispatched from a tag."
-            echo "Got ref: ${{ github.ref }}"
+          if ! gh api "repos/${{ github.repository }}/git/ref/tags/${{ inputs.tag }}" \
+              >/dev/null 2>&1; then
+            echo "ERROR: Tag '${{ inputs.tag }}' does not exist in ${{ github.repository }}."
             exit 1
           fi
-          echo "==> Dispatched from tag: ${{ github.ref_name }}"
+          echo "==> Tag exists: ${{ inputs.tag }}"
 
       - name: Require published release for tag
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if ! gh release view "${{ github.ref_name }}" \
+          if ! gh release view "${{ inputs.tag }}" \
               --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "ERROR: No GitHub release found for tag '${{ github.ref_name }}'."
+            echo "ERROR: No GitHub release found for tag '${{ inputs.tag }}'."
             echo "Generate the release (and release notes) before running this workflow."
             exit 1
           fi
-          echo "==> Release exists for tag: ${{ github.ref_name }}"
+          echo "==> Release exists for tag: ${{ inputs.tag }}"
 
   build:
     needs: guard
@@ -108,8 +118,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      # ── Checkout the ref that triggered this workflow ──
+      # ── Checkout the tag being released (NOT the dispatch ref) ──
+      # The workflow YAML is loaded from the dispatch ref, but the built
+      # source must come from the tag the user is releasing.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.tag }}
 
       # ── Set up build tools ──
       - name: Set up Python
@@ -326,7 +340,7 @@ jobs:
       - name: Create combined archive
         id: archive
         run: |
-          ARCHIVE="mptcrypto-natives-${{ github.ref_name }}.tar.gz"
+          ARCHIVE="mptcrypto-natives-${{ inputs.tag }}.tar.gz"
           tar -czf "${ARCHIVE}" -C natives .
           echo "==> Created ${ARCHIVE}"
           ls -lh "${ARCHIVE}"
@@ -338,7 +352,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" \
+          gh release upload "${{ inputs.tag }}" \
             "${{ steps.archive.outputs.archive }}" \
             --repo "${{ github.repository }}" \
             --clobber

--- a/.github/workflows/build-client-lib-natives.yml
+++ b/.github/workflows/build-client-lib-natives.yml
@@ -8,8 +8,9 @@
 # without any system-level installs on the consumer's machine.
 #
 # Triggers:
-#   - Push of a release tag (e.g. 0.3.0, 0.3.0-rc1)
-#   - Manual workflow_dispatch on any branch / tag / SHA (for testing)
+#   - workflow_dispatch ONLY, and the selected ref MUST be a tag that already
+#     has a published GitHub release (release notes generated). The guard job
+#     below enforces both preconditions and fails fast otherwise.
 #
 # The output artifacts follow the JNA platform-naming convention (also
 # compatible with Python ctypes lookups):
@@ -18,18 +19,50 @@
 #   linux-aarch64/libmptcrypto.so       (Linux ARM64)
 #   linux-x86-64/libmptcrypto.so        (Linux x86_64)
 #   win32-x86-64/mptcrypto.dll          (Windows x86_64)
+#
+# Binaries are attached to the existing GitHub release as assets (per-platform
+# tarballs + a combined bundle). Re-running on the same tag overwrites the
+# previously-uploaded assets of the same name via `gh release upload --clobber`.
 # ──────────────────────────────────────────────────────────────────────────────
 
 name: Build Native Binaries for Client Libraries
 
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
   workflow_dispatch:
 
 jobs:
+  # ──────────────────────────────────────────────────────────────────────────
+  # Gate: only proceed when dispatched from a tag ref that already has a
+  # published GitHub release. workflow_dispatch lets users pick any
+  # branch/tag/SHA from the UI, so we enforce both preconditions explicitly.
+  # ──────────────────────────────────────────────────────────────────────────
+  guard:
+    name: Verify tag + release exist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require tag ref
+        run: |
+          if [[ "${{ github.ref }}" != refs/tags/* ]]; then
+            echo "ERROR: This workflow must be dispatched from a tag."
+            echo "Got ref: ${{ github.ref }}"
+            exit 1
+          fi
+          echo "==> Dispatched from tag: ${{ github.ref_name }}"
+
+      - name: Require published release for tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh release view "${{ github.ref_name }}" \
+              --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "ERROR: No GitHub release found for tag '${{ github.ref_name }}'."
+            echo "Generate the release (and release notes) before running this workflow."
+            exit 1
+          fi
+          echo "==> Release exists for tag: ${{ github.ref_name }}"
+
   build:
+    needs: guard
     name: Build ${{ matrix.platform }}
     strategy:
       # Cancel in-flight matrix jobs as soon as any one fails — no point burning
@@ -262,7 +295,7 @@ jobs:
   #   win32-x86-64/mptcrypto.dll
   # ──────────────────────────────────────────────────────────────────────────
   bundle:
-    name: Bundle all native libraries
+    name: Bundle and attach to release
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -281,9 +314,24 @@ jobs:
           echo "==> File sizes:"
           find natives/ -type f -exec ls -lh {} \;
 
-      - name: Upload combined artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: mptcrypto-all-platforms
-          path: natives/
-          if-no-files-found: error
+      # Package the whole natives/ tree into a single archive. The tag is
+      # baked into the filename so downloaders can tell versions apart.
+      - name: Create combined archive
+        id: archive
+        run: |
+          ARCHIVE="mptcrypto-natives-${{ github.ref_name }}.tar.gz"
+          tar -czf "${ARCHIVE}" -C natives .
+          echo "==> Created ${ARCHIVE}"
+          ls -lh "${ARCHIVE}"
+          echo "archive=${ARCHIVE}" >> "${GITHUB_OUTPUT}"
+
+      # Attach the combined bundle to the existing GitHub release.
+      # --clobber overwrites any asset with the same name from a prior run.
+      - name: Upload to GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.ref_name }}" \
+            "${{ steps.archive.outputs.archive }}" \
+            --repo "${{ github.repository }}" \
+            --clobber

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -19,7 +19,13 @@
 #   darwin-x86-64/libmpt-crypto.dylib   (macOS x86_64)
 #   linux-aarch64/libmpt-crypto.so      (Linux ARM64)
 #   linux-x86-64/libmpt-crypto.so       (Linux x86_64)
+#   linux-s390x/libmpt-crypto.so        (Linux s390x, IBM Z — QEMU-built)
 #   win32-x86-64/mpt-crypto.dll         (Windows x86_64)
+#
+# Platforms without a native GitHub-hosted runner (s390x) are built inside a
+# --platform linux/<arch> Docker container via QEMU user-mode emulation.
+# The same .github/scripts/build-shared-lib.sh drives both the native and
+# the emulated builds — the workflow just decides where to run it.
 #
 # This workflow is invoked via `workflow_call` from build.yml — on every PR
 # and push to main (so the native-binary build path is exercised before a
@@ -65,89 +71,80 @@ jobs:
             platform: linux-x86-64
             lib_filename: libmpt-crypto.so
 
+          # ── Linux s390x (IBM Z) — built via QEMU user-mode emulation ──
+          # No native GHA runner exists for s390x. Builds and tests run
+          # inside a --platform linux/s390x container; QEMU emulates each
+          # instruction, so expect ~10-50x slower than native. Catches
+          # endianness bugs (s390x is big-endian) on every PR.
+          - os: ubuntu-latest
+            platform: linux-s390x
+            lib_filename: libmpt-crypto.so
+            docker_platform: linux/s390x
+            docker_image: s390x/ubuntu:24.04
+
           # ── Windows x86_64 ──
           - os: windows-latest
             platform: win32-x86-64
             lib_filename: mpt-crypto.dll
 
     runs-on: ${{ matrix.os }}
+    # Generous upper bound for the emulated s390x job (~30-60 min under
+    # QEMU when Conan has to build OpenSSL/secp256k1 from source).
+    # Native jobs finish in ~5-10 min and are unaffected.
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      # ── QEMU for non-native Linux targets (s390x today) ──
+      - name: Set up QEMU
+        if: matrix.docker_platform
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        with:
+          platforms: ${{ matrix.docker_platform }}
+
+      # ── Toolchain setup for native runners. Skipped for Docker builds,
+      # which install the same tooling inside the container below. ──
       - name: Set up Python
+        if: ${{ !matrix.docker_platform }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Install Conan and Ninja
+        if: ${{ !matrix.docker_platform }}
         run: pip install "conan>=2.0.0" ninja
 
       - name: Set up MSVC environment
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
 
-      - name: Configure Conan
+      # ── Build + test on the native runner (Linux/macOS/Windows) ──
+      - name: Build and test
+        if: ${{ !matrix.docker_platform }}
         shell: bash
-        run: |
-          conan profile detect --force
-          echo "==> Detected Conan profile:"
-          conan profile show
-          conan remote add --index 0 --force xrplf https://conan.ripplex.io
+        run: ./.github/scripts/build-shared-lib.sh
 
-      - name: Install dependencies
-        shell: bash
+      # ── Build + test inside a QEMU-emulated Linux container ──
+      # Everything — apt, pip, conan, cmake, ninja, the compiled binary,
+      # the test executables under ctest — runs translated through QEMU.
+      # Host/runner sees real big-endian ELF output under ./build/.
+      - name: Build and test in ${{ matrix.docker_platform }} container
+        if: matrix.docker_platform
         run: |
-          CONAN_ARGS=(
-            -of build
-            --build=missing
-            -s build_type=Release
-            -o "&:shared=True"
-            -o "&:tests=True"
-            -o "secp256k1/*:shared=False"
-            -o "openssl/*:shared=False"
-          )
-          if [[ "${RUNNER_OS}" != "Windows" ]]; then
-            CONAN_ARGS+=(-o "secp256k1/*:fPIC=True" -o "openssl/*:fPIC=True")
-          fi
-          conan install . "${CONAN_ARGS[@]}"
-
-      - name: Configure CMake
-        shell: bash
-        run: |
-          CMAKE_ARGS=(
-            -B build
-            -S .
-            -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake
-          )
-          if [[ "${RUNNER_OS}" == "Windows" ]]; then
-            CMAKE_ARGS+=(
-              -G "Visual Studio 17 2022"
-              -A x64
-              -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
-            )
-          else
-            CMAKE_ARGS+=(
-              -G Ninja
-              -DCMAKE_BUILD_TYPE=Release
-            )
-          fi
-          cmake "${CMAKE_ARGS[@]}"
-
-      - name: Build shared library
-        shell: bash
-        run: cmake --build build --config Release
-
-      - name: Run tests
-        shell: bash
-        working-directory: build
-        run: |
-          CTEST_ARGS=(--output-on-failure)
-          if [[ "${RUNNER_OS}" == "Windows" ]]; then
-            export PATH="$(pwd)/Release:${PATH}"
-            CTEST_ARGS+=(-C Release)
-          fi
-          ctest "${CTEST_ARGS[@]}"
+          docker run --rm --platform ${{ matrix.docker_platform }} \
+            -v "${PWD}:/work" -w /work \
+            ${{ matrix.docker_image }} \
+            bash -c '
+              set -eux
+              apt-get update -qq
+              DEBIAN_FRONTEND=noninteractive apt-get install -qq -y \
+                python3 python3-pip \
+                cmake ninja-build \
+                build-essential pkg-config ca-certificates git
+              pip install --break-system-packages "conan>=2.0.0"
+              ./.github/scripts/build-shared-lib.sh
+            '
 
       - name: Stage shared library under output/<platform>/
         shell: bash

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -30,7 +30,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 
+        description:
           "Release tag to build and attach binaries to (must already have a
           published GitHub release)"
         required: true

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -12,7 +12,9 @@
 # attempt at full portability (no musl, no MT CRT).
 #
 # The output artifacts use CMake's natural library names under per-platform
-# subdirectories (OS × arch):
+# subdirectories (OS × arch), plus the public headers shared across platforms:
+#   include/secp256k1_mpt.h             (public API)
+#   include/utility/mpt_utility.h       (public API)
 #   darwin-aarch64/libmpt-crypto.dylib  (macOS ARM64)
 #   darwin-x86-64/libmpt-crypto.dylib   (macOS x86_64)
 #   linux-aarch64/libmpt-crypto.so      (Linux ARM64)
@@ -33,16 +35,6 @@ name: Build Shared Libraries
 
 on:
   workflow_call:
-    inputs:
-      ref:
-        description:
-          "Git ref (tag or SHA) to check out and build. Passed directly to
-          actions/checkout."
-        required: true
-        type: string
-
-permissions:
-  contents: read
 
 jobs:
   build:
@@ -80,8 +72,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.ref }}
 
       # ── Set up build tools ──
       - name: Set up Python
@@ -104,114 +94,70 @@ jobs:
           conan profile show
           conan remote add --index 0 --force xrplf https://conan.ripplex.io
 
-      # ── Install dependencies via Conan ──
-      - name: Install dependencies (Unix)
-        if: runner.os != 'Windows'
+      - name: Install dependencies
         shell: bash
         run: |
-          conan install . \
-            -of build \
-            --build=missing \
-            -s build_type=Release \
-            -o "&:shared=True" \
-            -o "&:tests=True" \
-            -o "secp256k1/*:shared=False" \
-            -o "secp256k1/*:fPIC=True" \
-            -o "openssl/*:shared=False" \
-            -o "openssl/*:fPIC=True"
-
-      - name: Install dependencies (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          conan install . \
-            -of build \
-            --build=missing \
-            -s build_type=Release \
-            -o "&:shared=True" \
-            -o "&:tests=True" \
-            -o "secp256k1/*:shared=False" \
+          CONAN_ARGS=(
+            -of build
+            --build=missing
+            -s build_type=Release
+            -o "&:shared=True"
+            -o "&:tests=True"
+            -o "secp256k1/*:shared=False"
             -o "openssl/*:shared=False"
+          )
+          if [[ "${RUNNER_OS}" != "Windows" ]]; then
+            CONAN_ARGS+=(-o "secp256k1/*:fPIC=True" -o "openssl/*:fPIC=True")
+          fi
+          conan install . "${CONAN_ARGS[@]}"
 
-      # ── Configure CMake ──
-      - name: Configure CMake (Unix)
-        if: runner.os != 'Windows'
+      - name: Configure CMake
         shell: bash
         run: |
-          TOOLCHAIN=$(find build -name "conan_toolchain.cmake" -print -quit)
-          if [ -z "${TOOLCHAIN}" ]; then
-            echo "ERROR: Could not find conan_toolchain.cmake under build/"
-            find build -type f -name "*.cmake" | head -20
-            exit 1
+          CMAKE_ARGS=(
+            -B build
+            -S .
+            -DCMAKE_TOOLCHAIN_FILE:FILEPATH=build/generators/conan_toolchain.cmake
+          )
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            CMAKE_ARGS+=(
+              -G "Visual Studio 17 2022"
+              -A x64
+              -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
+            )
+          else
+            CMAKE_ARGS+=(
+              -G Ninja
+              -DCMAKE_BUILD_TYPE=Release
+            )
           fi
-          echo "==> Using toolchain: ${TOOLCHAIN}"
+          cmake "${CMAKE_ARGS[@]}"
 
-          cmake -B build -S . \
-            -G Ninja \
-            -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" \
-            -DCMAKE_BUILD_TYPE=Release
-
-      - name: Configure CMake (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          TOOLCHAIN=$(find build -name "conan_toolchain.cmake" -print -quit)
-          if [ -z "${TOOLCHAIN}" ]; then
-            echo "ERROR: Could not find conan_toolchain.cmake under build/"
-            find build -type f -name "*.cmake" | head -20
-            exit 1
-          fi
-          echo "==> Using toolchain: ${TOOLCHAIN}"
-
-          cmake -B build -S . \
-            -G "Visual Studio 17 2022" \
-            -A x64 \
-            -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" \
-            -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
-
-      # ── Build ──
       - name: Build shared library
         shell: bash
         run: cmake --build build --config Release
 
       # ── Test ──
-      - name: Run tests (Unix)
-        if: runner.os != 'Windows'
+      - name: Run tests
         shell: bash
-        run: ctest --output-on-failure
         working-directory: build
-
-      - name: Run tests (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
         run: |
-          export PATH="$(pwd)/Release:${PATH}"
-          ctest -C Release --output-on-failure
-        working-directory: build
+          CTEST_ARGS=(--output-on-failure)
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            export PATH="$(pwd)/Release:${PATH}"
+            CTEST_ARGS+=(-C Release)
+          fi
+          ctest "${CTEST_ARGS[@]}"
 
       # ── Stage ──
-      # Locate the built library (path varies by generator: build/ for Ninja,
-      # build/Release/ for Visual Studio) and place it under output/<platform>/
-      # so upload-artifact preserves the platform subdirectory.
       - name: Stage shared library under output/<platform>/
         shell: bash
+        env:
+          LIB_DIR: ${{ runner.os == 'Windows' && 'build/Release' || 'build' }}
         run: |
-          mkdir -p output/${{ matrix.platform }}
+          mkdir -p "output/${{ matrix.platform }}"
+          cp "${LIB_DIR}/${{ matrix.lib_filename }}" "output/${{ matrix.platform }}/"
 
-          BUILT_LIB=$(find build -maxdepth 2 -name "${{ matrix.lib_filename }}" -print -quit)
-
-          if [ -z "${BUILT_LIB}" ]; then
-            echo "ERROR: Could not find ${{ matrix.lib_filename }} in build/"
-            echo "Build directory contents:"
-            find build -type f \( -name "*.dylib" -o -name "*.so" -o -name "*.dll" \) 2>/dev/null
-            exit 1
-          fi
-
-          echo "==> Found: ${BUILT_LIB}"
-          cp "${BUILT_LIB}" "output/${{ matrix.platform }}/"
-          echo "==> Packaged: output/${{ matrix.platform }}/${{ matrix.lib_filename }}"
-
-      # ── Upload per-platform artifact ──
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -219,20 +165,17 @@ jobs:
           path: output/
           if-no-files-found: error
 
-  # ──────────────────────────────────────────────────────────────────────────
-  # Bundle all platform artifacts into a single downloadable archive.
-  #   darwin-aarch64/libmpt-crypto.dylib
-  #   darwin-x86-64/libmpt-crypto.dylib
-  #   linux-aarch64/libmpt-crypto.so
-  #   linux-x86-64/libmpt-crypto.so
-  #   win32-x86-64/mpt-crypto.dll
-  #
-  # ──────────────────────────────────────────────────────────────────────────
   bundle:
     name: Bundle platform artifacts
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repo (for public headers)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: include
+          sparse-checkout-cone-mode: false
+
       - name: Download all platform artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -240,19 +183,14 @@ jobs:
           path: natives/
           merge-multiple: true
 
-      - name: Display bundled structure
+      - name: Stage public headers
         run: |
-          echo "==> Bundled native libraries:"
-          find natives/ -type f | sort
-          echo ""
-          echo "==> File sizes:"
-          find natives/ -type f -exec ls -lh {} \;
+          mkdir -p natives/include
+          cp -R include/. natives/include/
 
       - name: Create combined archive
         run: |
           tar -czf mpt-crypto-natives.tar.gz -C natives .
-          echo "==> Created mpt-crypto-natives.tar.gz"
-          ls -lh mpt-crypto-natives.tar.gz
 
       - name: Upload combined bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -114,7 +114,7 @@ jobs:
             --build=missing \
             -s build_type=Release \
             -o "&:shared=True" \
-            -o "&:tests=False" \
+            -o "&:tests=True" \
             -o "secp256k1/*:shared=False" \
             -o "secp256k1/*:fPIC=True" \
             -o "openssl/*:shared=False" \
@@ -129,7 +129,7 @@ jobs:
             --build=missing \
             -s build_type=Release \
             -o "&:shared=True" \
-            -o "&:tests=False" \
+            -o "&:tests=True" \
             -o "secp256k1/*:shared=False" \
             -o "openssl/*:shared=False"
 
@@ -173,6 +173,21 @@ jobs:
       - name: Build shared library
         shell: bash
         run: cmake --build build --config Release
+
+      # ── Test ──
+      - name: Run tests (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: ctest --output-on-failure
+        working-directory: build
+
+      - name: Run tests (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          export PATH="$(pwd)/Release:${PATH}"
+          ctest -C Release --output-on-failure
+        working-directory: build
 
       # ── Stage ──
       # Locate the built library (path varies by generator: build/ for Ninja,

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -39,6 +39,8 @@ on:
 jobs:
   build:
     name: Build ${{ matrix.platform }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -73,7 +75,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # ── Set up build tools ──
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -137,7 +138,6 @@ jobs:
         shell: bash
         run: cmake --build build --config Release
 
-      # ── Test ──
       - name: Run tests
         shell: bash
         working-directory: build
@@ -149,7 +149,6 @@ jobs:
           fi
           ctest "${CTEST_ARGS[@]}"
 
-      # ── Stage ──
       - name: Stage shared library under output/<platform>/
         shell: bash
         env:
@@ -168,6 +167,8 @@ jobs:
   bundle:
     name: Bundle platform artifacts
     needs: build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo (for public headers)

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -11,7 +11,6 @@
 # on macOS, glibc/libstdc++ on Linux, Universal CRT on Windows) — there is no
 # attempt at full portability (no musl, no MT CRT).
 #
-#
 # The output artifacts use CMake's natural library names under per-platform
 # subdirectories (OS × arch):
 #   darwin-aarch64/libmpt-crypto.dylib  (macOS ARM64)
@@ -20,19 +19,25 @@
 #   linux-x86-64/libmpt-crypto.so       (Linux x86_64)
 #   win32-x86-64/mpt-crypto.dll         (Windows x86_64)
 #
-# A single combined archive (mpt-crypto-natives-<tag>.tar.gz) is attached to
-# the release.
+# This workflow is invoked via `workflow_call` from build.yml — on every PR
+# and push to main (so the native-binary build path is exercised before a
+# release), and on tag push (so build.yml can cut a release with the bundle
+# attached atomically).
+#
+# The `bundle` job uploads the combined archive as a workflow artifact named
+# `mpt-crypto-natives-bundle`, which the caller downloads and attaches to the
+# GitHub release.
 # ──────────────────────────────────────────────────────────────────────────────
 
 name: Build Shared Libraries
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
-      tag:
+      ref:
         description:
-          "Release tag to build and attach binaries to (must already have a
-          published GitHub release)"
+          "Git ref (tag or SHA) to check out and build. Passed directly to
+          actions/checkout."
         required: true
         type: string
 
@@ -40,35 +45,7 @@ permissions:
   contents: read
 
 jobs:
-  guard:
-    name: Verify tag + release exist
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require tag exists in repo
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if ! gh api "repos/${{ github.repository }}/git/ref/tags/${{ inputs.tag }}" \
-              >/dev/null 2>&1; then
-            echo "ERROR: Tag '${{ inputs.tag }}' does not exist in ${{ github.repository }}."
-            exit 1
-          fi
-          echo "==> Tag exists: ${{ inputs.tag }}"
-
-      - name: Require published release for tag
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if ! gh release view "${{ inputs.tag }}" \
-              --repo "${{ github.repository }}" >/dev/null 2>&1; then
-            echo "ERROR: No GitHub release found for tag '${{ inputs.tag }}'."
-            echo "Generate the release (and release notes) before running this workflow."
-            exit 1
-          fi
-          echo "==> Release exists for tag: ${{ inputs.tag }}"
-
   build:
-    needs: guard
     name: Build ${{ matrix.platform }}
     strategy:
       fail-fast: false
@@ -104,7 +81,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.ref }}
 
       # ── Set up build tools ──
       - name: Set up Python
@@ -234,13 +211,12 @@ jobs:
   #   linux-aarch64/libmpt-crypto.so
   #   linux-x86-64/libmpt-crypto.so
   #   win32-x86-64/mpt-crypto.dll
+  #
   # ──────────────────────────────────────────────────────────────────────────
   bundle:
-    name: Bundle and attach to release
+    name: Bundle platform artifacts
     needs: build
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Download all platform artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -258,20 +234,14 @@ jobs:
           find natives/ -type f -exec ls -lh {} \;
 
       - name: Create combined archive
-        id: archive
         run: |
-          ARCHIVE="mpt-crypto-natives-${{ inputs.tag }}.tar.gz"
-          tar -czf "${ARCHIVE}" -C natives .
-          echo "==> Created ${ARCHIVE}"
-          ls -lh "${ARCHIVE}"
-          echo "archive=${ARCHIVE}" >> "${GITHUB_OUTPUT}"
+          tar -czf mpt-crypto-natives.tar.gz -C natives .
+          echo "==> Created mpt-crypto-natives.tar.gz"
+          ls -lh mpt-crypto-natives.tar.gz
 
-      # Attach the combined bundle to the existing GitHub release.
-      - name: Upload to GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release upload "${{ inputs.tag }}" \
-            "${{ steps.archive.outputs.archive }}" \
-            --repo "${{ github.repository }}" \
-            --clobber
+      - name: Upload combined bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mpt-crypto-natives-bundle
+          path: mpt-crypto-natives.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -72,10 +72,6 @@ jobs:
             lib_filename: libmpt-crypto.so
 
           # ── Linux s390x (IBM Z) — built via QEMU user-mode emulation ──
-          # No native GHA runner exists for s390x. Builds and tests run
-          # inside a --platform linux/s390x container; QEMU emulates each
-          # instruction, so expect ~10-50x slower than native. Catches
-          # endianness bugs (s390x is big-endian) on every PR.
           - os: ubuntu-latest
             platform: linux-s390x
             lib_filename: libmpt-crypto.so
@@ -88,23 +84,16 @@ jobs:
             lib_filename: mpt-crypto.dll
 
     runs-on: ${{ matrix.os }}
-    # Generous upper bound for the emulated s390x job (~30-60 min under
-    # QEMU when Conan has to build OpenSSL/secp256k1 from source).
-    # Native jobs finish in ~5-10 min and are unaffected.
-    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # ── QEMU for non-native Linux targets (s390x today) ──
       - name: Set up QEMU
         if: matrix.docker_platform
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           platforms: ${{ matrix.docker_platform }}
 
-      # ── Toolchain setup for native runners. Skipped for Docker builds,
-      # which install the same tooling inside the container below. ──
       - name: Set up Python
         if: ${{ !matrix.docker_platform }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
@@ -119,16 +108,11 @@ jobs:
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
 
-      # ── Build + test on the native runner (Linux/macOS/Windows) ──
       - name: Build and test
         if: ${{ !matrix.docker_platform }}
         shell: bash
         run: ./.github/scripts/build-shared-lib.sh
 
-      # ── Build + test inside a QEMU-emulated Linux container ──
-      # Everything — apt, pip, conan, cmake, ninja, the compiled binary,
-      # the test executables under ctest — runs translated through QEMU.
-      # Host/runner sees real big-endian ELF output under ./build/.
       - name: Build and test in ${{ matrix.docker_platform }} container
         if: matrix.docker_platform
         run: |

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -89,32 +89,32 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up QEMU
-        if: matrix.docker_platform
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        if: matrix.docker_platform != ''
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
         with:
           platforms: ${{ matrix.docker_platform }}
 
       - name: Set up Python
-        if: ${{ !matrix.docker_platform }}
+        if: matrix.docker_platform == ''
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Install Conan and Ninja
-        if: ${{ !matrix.docker_platform }}
-        run: pip install "conan>=2.0.0" ninja
+        if: matrix.docker_platform == ''
+        run: pip install conan ninja
 
       - name: Set up MSVC environment
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
 
       - name: Build and test
-        if: ${{ !matrix.docker_platform }}
+        if: matrix.docker_platform == ''
         shell: bash
         run: ./.github/scripts/build-shared-lib.sh
 
       - name: Build and test in ${{ matrix.docker_platform }} container
-        if: matrix.docker_platform
+        if: matrix.docker_platform != ''
         run: |
           docker run --rm --platform ${{ matrix.docker_platform }} \
             -v "${PWD}:/work" -w /work \
@@ -126,7 +126,7 @@ jobs:
                 python3 python3-pip \
                 cmake ninja-build \
                 build-essential pkg-config ca-certificates git
-              pip install --break-system-packages "conan>=2.0.0"
+              pip install --break-system-packages conan
               ./.github/scripts/build-shared-lib.sh
             '
 

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -188,6 +188,7 @@ jobs:
 
           cmake -B build -S . \
             -G "Visual Studio 17 2022" \
+            -A x64 \
             -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN}" \
             -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=ON
 

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -30,7 +30,8 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to build and attach binaries to (must already have a
+        description: 
+          "Release tag to build and attach binaries to (must already have a
           published GitHub release)"
         required: true
         type: string

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -1,54 +1,44 @@
 # ──────────────────────────────────────────────────────────────────────────────
-# Build Native Binaries for Client Libraries
+# Build Shared Libraries
 #
-# Builds the mpt-crypto C library as a self-contained shared library for each
-# supported platform, producing binaries that client libraries (xrpl4j via JNA,
-# xrpl-py via ctypes, etc.) can load directly at runtime. Dependencies
-# (secp256k1, OpenSSL) are statically linked so the resulting binaries work
-# without any system-level installs on the consumer's machine.
+# Builds the mpt-crypto C library as a shared library (.dylib / .so / .dll)
+# for each supported platform, producing binaries that client libraries
+# (xrpl4j via JNA, xrpl-py via ctypes, etc.) can load directly at runtime.
 #
-# Triggers:
-#   - workflow_dispatch ONLY. Dispatch from the branch that hosts this YAML
-#     (so the workflow definition is picked up), and pass the release `tag`
-#     as an input. The guard job below fails fast unless a GitHub release
-#     already exists for that tag (release notes generated). The build jobs
-#     check out the tag — so the YAML ref and the built source are decoupled.
+# secp256k1 and OpenSSL are linked statically INTO the shared library, so
+# consumers do not need either installed on the target machine. The shared
+# library itself still has the usual OS-level dynamic dependencies (libSystem
+# on macOS, glibc/libstdc++ on Linux, Universal CRT on Windows) — there is no
+# attempt at full portability (no musl, no MT CRT).
 #
-# The output artifacts follow the JNA platform-naming convention (also
-# compatible with Python ctypes lookups):
-#   darwin-aarch64/libmptcrypto.dylib   (macOS ARM64)
-#   darwin-x86-64/libmptcrypto.dylib    (macOS x86_64)
-#   linux-aarch64/libmptcrypto.so       (Linux ARM64)
-#   linux-x86-64/libmptcrypto.so        (Linux x86_64)
-#   win32-x86-64/mptcrypto.dll          (Windows x86_64)
 #
-# A single combined archive (mptcrypto-natives-<tag>.tar.gz) is attached to
-# the release. Re-running on the same tag overwrites the previously-uploaded
-# asset via `gh release upload --clobber`.
+# The output artifacts use CMake's natural library names under per-platform
+# subdirectories (OS × arch):
+#   darwin-aarch64/libmpt-crypto.dylib  (macOS ARM64)
+#   darwin-x86-64/libmpt-crypto.dylib   (macOS x86_64)
+#   linux-aarch64/libmpt-crypto.so      (Linux ARM64)
+#   linux-x86-64/libmpt-crypto.so       (Linux x86_64)
+#   win32-x86-64/mpt-crypto.dll         (Windows x86_64)
+#
+# A single combined archive (mpt-crypto-natives-<tag>.tar.gz) is attached to
+# the release.
 # ──────────────────────────────────────────────────────────────────────────────
 
-name: Build Native Binaries for Client Libraries
+name: Build Shared Libraries
 
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to build and attach binaries to (must already have a published GitHub release)"
+        description: "Release tag to build and attach binaries to (must already have a
+          published GitHub release)"
         required: true
         type: string
 
-# Default to read-only; the bundle job escalates to contents: write so it can
-# attach assets to the release via `gh release upload`.
 permissions:
   contents: read
 
 jobs:
-  # ──────────────────────────────────────────────────────────────────────────
-  # Gate: verify the `tag` input points at a real tag with a published
-  # GitHub release. The workflow YAML is loaded from whatever branch the
-  # user dispatched from (typically the branch hosting this file); the tag
-  # identifies what source gets built and where assets get attached.
-  # ──────────────────────────────────────────────────────────────────────────
   guard:
     name: Verify tag + release exist
     runs-on: ubuntu-latest
@@ -80,47 +70,37 @@ jobs:
     needs: guard
     name: Build ${{ matrix.platform }}
     strategy:
-      # Cancel in-flight matrix jobs as soon as any one fails — no point burning
-      # runner minutes on 4 more builds when the release is already broken.
       fail-fast: false
       matrix:
         include:
           # ── macOS ARM64 (Apple Silicon) ──
           - os: macos-14
             platform: darwin-aarch64
-            lib_filename: libmptcrypto.dylib
-            cmake_lib_filename: libmpt-crypto.dylib
+            lib_filename: libmpt-crypto.dylib
 
           # ── macOS x86_64 (Intel) ──
           - os: macos-15-intel
             platform: darwin-x86-64
-            lib_filename: libmptcrypto.dylib
-            cmake_lib_filename: libmpt-crypto.dylib
+            lib_filename: libmpt-crypto.dylib
 
           # ── Linux ARM64 ──
           - os: ubuntu-24.04-arm
             platform: linux-aarch64
-            lib_filename: libmptcrypto.so
-            cmake_lib_filename: libmpt-crypto.so
+            lib_filename: libmpt-crypto.so
 
           # ── Linux x86_64 ──
           - os: ubuntu-latest
             platform: linux-x86-64
-            lib_filename: libmptcrypto.so
-            cmake_lib_filename: libmpt-crypto.so
+            lib_filename: libmpt-crypto.so
 
           # ── Windows x86_64 ──
           - os: windows-latest
             platform: win32-x86-64
-            lib_filename: mptcrypto.dll
-            cmake_lib_filename: mpt-crypto.dll
+            lib_filename: mpt-crypto.dll
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      # ── Checkout the tag being released (NOT the dispatch ref) ──
-      # The workflow YAML is loaded from the dispatch ref, but the built
-      # source must come from the tag the user is releasing.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.tag }}
@@ -134,44 +114,26 @@ jobs:
       - name: Install Conan and Ninja
         run: pip install "conan>=2.0.0" ninja
 
-      # Windows needs the MSVC developer environment for cl.exe, link.exe, etc.
-      # NOTE: upstream msvc-dev-cmd is still on Node 20 — no Node 24 release yet.
-      # GitHub's Node 20 deprecation warning is expected here until upstream ships.
       - name: Set up MSVC environment
         if: runner.os == 'Windows'
         uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
 
-      # ── Configure Conan ──
-      # Use auto-detected profile so we don't need to hand-craft compiler
-      # settings for each platform. Then add the XRPLF remote where secp256k1
-      # packages are hosted.
       - name: Configure Conan
         shell: bash
         run: |
           conan profile detect --force
           echo "==> Detected Conan profile:"
           conan profile show
-          conan remote add --index 0 xrplf https://conan.ripplex.io || true
+          conan remote add --index 0 --force xrplf https://conan.ripplex.io
 
       # ── Install dependencies via Conan ──
-      #
-      # Key flags:
-      #   -o "&:shared=True"             → Build mpt-crypto as a SHARED library
-      #   -o "&:tests=False"             → Skip building test executables
-      #   -o "secp256k1/*:shared=False"  → Static secp256k1, linked INTO the shared lib
-      #   -o "openssl/*:shared=False"    → Static OpenSSL, linked INTO the shared lib
-      #   -o "*/fPIC=True"               → Position Independent Code for static deps
-      #                                    (required when linking static libs into a .so/.dylib)
-      #   -b missing                     → Build deps from source if no pre-built binary
-      #
-      # On Windows, fPIC doesn't apply — Conan ignores it for MSVC targets.
       - name: Install dependencies (Unix)
         if: runner.os != 'Windows'
         shell: bash
         run: |
           conan install . \
             -of build \
-            -b missing \
+            --build=missing \
             -s build_type=Release \
             -o "&:shared=True" \
             -o "&:tests=False" \
@@ -186,7 +148,7 @@ jobs:
         run: |
           conan install . \
             -of build \
-            -b missing \
+            --build=missing \
             -s build_type=Release \
             -o "&:shared=True" \
             -o "&:tests=False" \
@@ -194,14 +156,6 @@ jobs:
             -o "openssl/*:shared=False"
 
       # ── Configure CMake ──
-      #
-      # The Conan toolchain file (conan_toolchain.cmake) configures:
-      #   - CMAKE_BUILD_TYPE=Release (single-config generators)
-      #   - BUILD_SHARED_LIBS=ON (from shared=True)
-      #   - Find-package paths for secp256k1 and OpenSSL
-      #
-      # Windows uses the VS generator because Ninja doesn't support
-      # CMAKE_GENERATOR_PLATFORM which Conan's MSVC toolchain sets.
       - name: Configure CMake (Unix)
         if: runner.os != 'Windows'
         shell: bash
@@ -241,77 +195,43 @@ jobs:
         shell: bash
         run: cmake --build build --config Release
 
-      # ── Package ──
-      # CMake produces "mpt-crypto" (with hyphen) as the library name.
-      # We rename to "mptcrypto" (no hyphen) because JNA's Native.load("mptcrypto")
-      # expects this convention.
-      - name: Package library
+      # ── Stage ──
+      # Locate the built library (path varies by generator: build/ for Ninja,
+      # build/Release/ for Visual Studio) and place it under output/<platform>/
+      # so upload-artifact preserves the platform subdirectory.
+      - name: Stage shared library under output/<platform>/
         shell: bash
         run: |
           mkdir -p output/${{ matrix.platform }}
 
-          BUILT_LIB=$(find build -maxdepth 2 \( \
-            -name "${{ matrix.cmake_lib_filename }}" \
-            \) -print -quit)
+          BUILT_LIB=$(find build -maxdepth 2 -name "${{ matrix.lib_filename }}" -print -quit)
 
           if [ -z "${BUILT_LIB}" ]; then
-            echo "ERROR: Could not find ${{ matrix.cmake_lib_filename }} in build/"
+            echo "ERROR: Could not find ${{ matrix.lib_filename }} in build/"
             echo "Build directory contents:"
             find build -type f \( -name "*.dylib" -o -name "*.so" -o -name "*.dll" \) 2>/dev/null
             exit 1
           fi
 
           echo "==> Found: ${BUILT_LIB}"
-          cp "${BUILT_LIB}" "output/${{ matrix.platform }}/${{ matrix.lib_filename }}"
+          cp "${BUILT_LIB}" "output/${{ matrix.platform }}/"
           echo "==> Packaged: output/${{ matrix.platform }}/${{ matrix.lib_filename }}"
 
-      # ── Verify ──
-      # Confirm the library is self-contained: linked libraries should only be
-      # system libs (no secp256k1 or libcrypto as external shared deps).
-      - name: Verify library (macOS)
-        if: startsWith(matrix.platform, 'darwin')
-        run: |
-          echo "==> Linked libraries (should only show system libs):"
-          otool -L output/${{ matrix.platform }}/${{ matrix.lib_filename }}
-          echo ""
-          echo "==> Architecture:"
-          file output/${{ matrix.platform }}/${{ matrix.lib_filename }}
-
-      - name: Verify library (Linux)
-        if: startsWith(matrix.platform, 'linux')
-        run: |
-          echo "==> Linked libraries (should only show system libs):"
-          ldd output/${{ matrix.platform }}/${{ matrix.lib_filename }} || true
-          echo ""
-          echo "==> Architecture:"
-          file output/${{ matrix.platform }}/${{ matrix.lib_filename }}
-
-      - name: Verify library (Windows)
-        if: startsWith(matrix.platform, 'win32')
-        shell: bash
-        run: |
-          echo "==> File info:"
-          file output/${{ matrix.platform }}/${{ matrix.lib_filename }}
-
       # ── Upload per-platform artifact ──
-      # Upload output/ (not output/<platform>/) so the platform subdirectory
-      # is preserved inside the artifact. This ensures merge-multiple in the
-      # bundle job doesn't overwrite files with the same name across platforms.
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: mptcrypto-${{ matrix.platform }}
+          name: mpt-crypto-${{ matrix.platform }}
           path: output/
           if-no-files-found: error
 
   # ──────────────────────────────────────────────────────────────────────────
   # Bundle all platform artifacts into a single downloadable archive.
-  # The structure matches what JNA expects on the classpath:
-  #   darwin-aarch64/libmptcrypto.dylib
-  #   darwin-x86-64/libmptcrypto.dylib
-  #   linux-aarch64/libmptcrypto.so
-  #   linux-x86-64/libmptcrypto.so
-  #   win32-x86-64/mptcrypto.dll
+  #   darwin-aarch64/libmpt-crypto.dylib
+  #   darwin-x86-64/libmpt-crypto.dylib
+  #   linux-aarch64/libmpt-crypto.so
+  #   linux-x86-64/libmpt-crypto.so
+  #   win32-x86-64/mpt-crypto.dll
   # ──────────────────────────────────────────────────────────────────────────
   bundle:
     name: Bundle and attach to release
@@ -323,7 +243,7 @@ jobs:
       - name: Download all platform artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: mptcrypto-*
+          pattern: mpt-crypto-*
           path: natives/
           merge-multiple: true
 
@@ -335,19 +255,16 @@ jobs:
           echo "==> File sizes:"
           find natives/ -type f -exec ls -lh {} \;
 
-      # Package the whole natives/ tree into a single archive. The tag is
-      # baked into the filename so downloaders can tell versions apart.
       - name: Create combined archive
         id: archive
         run: |
-          ARCHIVE="mptcrypto-natives-${{ inputs.tag }}.tar.gz"
+          ARCHIVE="mpt-crypto-natives-${{ inputs.tag }}.tar.gz"
           tar -czf "${ARCHIVE}" -C natives .
           echo "==> Created ${ARCHIVE}"
           ls -lh "${ARCHIVE}"
           echo "archive=${ARCHIVE}" >> "${GITHUB_OUTPUT}"
 
       # Attach the combined bundle to the existing GitHub release.
-      # --clobber overwrites any asset with the same name from a prior run.
       - name: Upload to GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build and Test
+name: Build, Test and Release
 
 on:
   pull_request:
@@ -105,14 +105,7 @@ jobs:
   # On tag push only: publish a GitHub release and attach the native bundle.
   release:
     name: Publish release
-    # Run on tag push when native-binaries succeeded, and either build-and-test
-    # passed (upstream) or was skipped (fork). `!failure() && !cancelled()`
-    # is the GH Actions idiom to override the default "skip if any need was
-    # skipped" behavior without also running on real failures.
-    if: >-
-      !failure() && !cancelled() &&
-      github.ref_type == 'tag' &&
-      needs.native-binaries.result == 'success'
+    if: github.ref_type == 'tag'
     needs: [build-and-test, native-binaries]
     runs-on: ubuntu-latest
     permissions:
@@ -127,14 +120,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ ! -f mpt-crypto-natives.tar.gz ]; then
-            echo "ERROR: mpt-crypto-natives.tar.gz not found in downloaded bundle"
-            ls -la
-            exit 1
-          fi
           ARCHIVE="mpt-crypto-natives-${GITHUB_REF_NAME}.tar.gz"
           mv mpt-crypto-natives.tar.gz "${ARCHIVE}"
-          echo "==> Publishing release ${GITHUB_REF_NAME} with ${ARCHIVE}"
           gh release create "${GITHUB_REF_NAME}" \
             "${ARCHIVE}" \
             --repo "${GITHUB_REPOSITORY}" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     # macos15), which aren't shared with forks. Skip on forks so workflow
     # changes can be iterated on without stalling in the runner queue.
     if: github.repository_owner == 'XRPLF'
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -100,6 +102,8 @@ jobs:
   # the reusable workflow.
   native-binaries:
     name: Build native shared libraries
+    permissions:
+      contents: read
     uses: ./.github/workflows/build-shared-libs.yml
 
   # On tag push only: publish a GitHub release and attach the native bundle.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,16 +96,11 @@ jobs:
         run: ctest --output-on-failure
         working-directory: ${{ env.BUILD_DIR }}
 
-  # ──────────────────────────────────────────────────────────────────────────
   # Build the shared-library bundle (per-platform .so/.dylib/.dll) by calling
-  # the reusable workflow. Runs on every PR, main push, and tag push — so the
-  # native-binary build path is always exercised, not just at release time.
-  # ──────────────────────────────────────────────────────────────────────────
+  # the reusable workflow.
   native-binaries:
     name: Build native shared libraries
     uses: ./.github/workflows/build-shared-libs.yml
-    with:
-      ref: ${{ github.sha }}
 
   # On tag push only: publish a GitHub release and attach the native bundle.
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ concurrency:
 
 jobs:
   build-and-test:
+    # The matrix depends on XRPLF's self-hosted runners (heavy, heavy-arm64,
+    # macos15), which aren't shared with forks. Skip on forks so workflow
+    # changes can be iterated on without stalling in the runner queue.
+    if: github.repository_owner == 'XRPLF'
     strategy:
       fail-fast: false
       matrix:
@@ -106,7 +110,14 @@ jobs:
   # On tag push only: publish a GitHub release and attach the native bundle.
   release:
     name: Publish release
-    if: github.ref_type == 'tag'
+    # Run on tag push when native-binaries succeeded, and either build-and-test
+    # passed (upstream) or was skipped (fork). `!failure() && !cancelled()`
+    # is the GH Actions idiom to override the default "skip if any need was
+    # skipped" behavior without also running on real failures.
+    if: >-
+      !failure() && !cancelled() &&
+      github.ref_type == 'tag' &&
+      needs.native-binaries.result == 'success'
     needs: [build-and-test, native-binaries]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: [main]
+    tags: ["[0-9]*.[0-9]*.[0-9]*"]
   workflow_dispatch:
 
 concurrency:
@@ -90,3 +91,45 @@ jobs:
       - name: Run tests
         run: ctest --output-on-failure
         working-directory: ${{ env.BUILD_DIR }}
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Build the shared-library bundle (per-platform .so/.dylib/.dll) by calling
+  # the reusable workflow. Runs on every PR, main push, and tag push — so the
+  # native-binary build path is always exercised, not just at release time.
+  # ──────────────────────────────────────────────────────────────────────────
+  native-binaries:
+    name: Build native shared libraries
+    uses: ./.github/workflows/build-shared-libs.yml
+    with:
+      ref: ${{ github.sha }}
+
+  # On tag push only: publish a GitHub release and attach the native bundle.
+  release:
+    name: Publish release
+    if: github.ref_type == 'tag'
+    needs: [build-and-test, native-binaries]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download native bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mpt-crypto-natives-bundle
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ ! -f mpt-crypto-natives.tar.gz ]; then
+            echo "ERROR: mpt-crypto-natives.tar.gz not found in downloaded bundle"
+            ls -la
+            exit 1
+          fi
+          ARCHIVE="mpt-crypto-natives-${GITHUB_REF_NAME}.tar.gz"
+          mv mpt-crypto-natives.tar.gz "${ARCHIVE}"
+          echo "==> Publishing release ${GITHUB_REF_NAME} with ${ARCHIVE}"
+          gh release create "${GITHUB_REF_NAME}" \
+            "${ARCHIVE}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --generate-notes

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 cmake-build-*/
 .idea/
 .venv
+.vscode/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,57 +39,61 @@ add_mpt_test(test_equality_proof test_equality_proof.c DEPENDENCIES mpt-crypto)
 add_mpt_test(
     test_link_proof
     test_link_proof.c
-    DEPENDENCIES mpt-crypto secp256k1 OpenSSL::Crypto
+    DEPENDENCIES mpt-crypto secp256k1::secp256k1 OpenSSL::Crypto
 )
 
 add_mpt_test(
     test_elgamal_verify
     test_elgamal_verify.c
-    DEPENDENCIES mpt-crypto secp256k1
+    DEPENDENCIES mpt-crypto secp256k1::secp256k1
 )
 
-add_mpt_test(test_pok_sk test_pok_sk.c DEPENDENCIES mpt-crypto secp256k1)
+add_mpt_test(
+    test_pok_sk
+    test_pok_sk.c
+    DEPENDENCIES mpt-crypto secp256k1::secp256k1
+)
 
 add_mpt_test(
     test_commitments
     test_commitments.c
-    DEPENDENCIES mpt-crypto secp256k1
+    DEPENDENCIES mpt-crypto secp256k1::secp256k1
 )
 
-add_mpt_test(test_ipa test_ipa.c DEPENDENCIES mpt-crypto secp256k1)
+add_mpt_test(test_ipa test_ipa.c DEPENDENCIES mpt-crypto secp256k1::secp256k1)
 
 add_mpt_test(
     test_same_plaintext_multi_shared_r
     test_same_plaintext_multi_shared_r.c
-    DEPENDENCIES mpt-crypto secp256k1
+    DEPENDENCIES mpt-crypto secp256k1::secp256k1
 )
 
 add_mpt_test(
     test_bulletproof_agg
     test_bulletproof_agg.c
-    DEPENDENCIES mpt-crypto secp256k1
+    DEPENDENCIES mpt-crypto secp256k1::secp256k1
 )
 
 add_mpt_test(
     test_mpt_utility
     test_mpt_utility.cpp
-    DEPENDENCIES mpt-crypto secp256k1 OpenSSL::Crypto
+    DEPENDENCIES mpt-crypto secp256k1::secp256k1 OpenSSL::Crypto
 )
 
 add_mpt_test(
     test_compact_standard
     test_compact_standard.c
-    DEPENDENCIES mpt-crypto secp256k1
+    DEPENDENCIES mpt-crypto secp256k1::secp256k1
 )
 
 add_mpt_test(
     test_compact_clawback
     test_compact_clawback.c
-    DEPENDENCIES mpt-crypto secp256k1
+    DEPENDENCIES mpt-crypto secp256k1::secp256k1
 )
 
 add_mpt_test(
     test_compact_convertback
     test_compact_convertback.c
-    DEPENDENCIES mpt-crypto secp256k1
+    DEPENDENCIES mpt-crypto secp256k1::secp256k1
 )

--- a/tests/test_bulletproof_agg.c
+++ b/tests/test_bulletproof_agg.c
@@ -6,27 +6,6 @@
 #include <string.h>
 #include <time.h>
 
-#ifdef _WIN32
-/* MSVC's <time.h> has struct timespec but not CLOCK_MONOTONIC / clock_gettime.
- * Shim them with QueryPerformanceCounter so the benchmark timing below works
- * on Windows without touching the call sites. */
-#include <windows.h>
-#ifndef CLOCK_MONOTONIC
-#define CLOCK_MONOTONIC 0
-#endif
-static int clock_gettime(int clk_id, struct timespec *ts)
-{
-  (void)clk_id;
-  LARGE_INTEGER freq, count;
-  QueryPerformanceFrequency(&freq);
-  QueryPerformanceCounter(&count);
-  ts->tv_sec = (time_t)(count.QuadPart / freq.QuadPart);
-  ts->tv_nsec =
-      (long)(((count.QuadPart % freq.QuadPart) * 1000000000LL) / freq.QuadPart);
-  return 0;
-}
-#endif
-
 #define BP_VALUE_BITS 64
 #define BP_TOTAL_BITS(m) ((size_t)(BP_VALUE_BITS * (m)))
 #define VERIFY_RUNS 5
@@ -78,26 +57,26 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
   size_t proof_len = sizeof(proof);
 
   struct timespec t_p_start, t_p_end;
-  clock_gettime(CLOCK_MONOTONIC, &t_p_start);
+  timespec_get(&t_p_start, TIME_UTC);
 
   EXPECT(secp256k1_bulletproof_prove_agg(ctx, proof, &proof_len, values,
                                          (const unsigned char *)blindings,
                                          num_values, &pk_base, context_id));
 
-  clock_gettime(CLOCK_MONOTONIC, &t_p_end);
+  timespec_get(&t_p_end, TIME_UTC);
   printf("  Proof size: %zu bytes\n", proof_len);
   if (run_benchmarks)
     printf("  [BENCH] Proving time: %.3f ms\n", elapsed_ms(t_p_start, t_p_end));
 
   /* ---- Verify ---- */
   struct timespec t_v_start, t_v_end;
-  clock_gettime(CLOCK_MONOTONIC, &t_v_start);
+  timespec_get(&t_v_start, TIME_UTC);
 
   int ok = secp256k1_bulletproof_verify_agg(ctx, G_vec, H_vec, proof, proof_len,
                                             commitments, num_values, &pk_base,
                                             context_id);
 
-  clock_gettime(CLOCK_MONOTONIC, &t_v_end);
+  timespec_get(&t_v_end, TIME_UTC);
   EXPECT(ok);
   printf("  PASSED (Verification)\n");
   if (run_benchmarks)
@@ -111,11 +90,11 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
     for (int i = 0; i < VERIFY_RUNS; i++)
     {
       struct timespec ts, te;
-      clock_gettime(CLOCK_MONOTONIC, &ts);
+      timespec_get(&ts, TIME_UTC);
       ok = secp256k1_bulletproof_verify_agg(ctx, G_vec, H_vec, proof, proof_len,
                                             commitments, num_values, &pk_base,
                                             context_id);
-      clock_gettime(CLOCK_MONOTONIC, &te);
+      timespec_get(&te, TIME_UTC);
       EXPECT(ok);
       total_ms += elapsed_ms(ts, te);
     }

--- a/tests/test_bulletproof_agg.c
+++ b/tests/test_bulletproof_agg.c
@@ -6,6 +6,27 @@
 #include <string.h>
 #include <time.h>
 
+#ifdef _WIN32
+/* MSVC's <time.h> has struct timespec but not CLOCK_MONOTONIC / clock_gettime.
+ * Shim them with QueryPerformanceCounter so the benchmark timing below works
+ * on Windows without touching the call sites. */
+#include <windows.h>
+#ifndef CLOCK_MONOTONIC
+#define CLOCK_MONOTONIC 0
+#endif
+static int clock_gettime(int clk_id, struct timespec *ts)
+{
+  (void)clk_id;
+  LARGE_INTEGER freq, count;
+  QueryPerformanceFrequency(&freq);
+  QueryPerformanceCounter(&count);
+  ts->tv_sec = (time_t)(count.QuadPart / freq.QuadPart);
+  ts->tv_nsec =
+      (long)(((count.QuadPart % freq.QuadPart) * 1000000000LL) / freq.QuadPart);
+  return 0;
+}
+#endif
+
 #define BP_VALUE_BITS 64
 #define BP_TOTAL_BITS(m) ((size_t)(BP_VALUE_BITS * (m)))
 #define VERIFY_RUNS 5

--- a/tests/test_same_plaintext_multi_shared_r.c
+++ b/tests/test_same_plaintext_multi_shared_r.c
@@ -62,7 +62,8 @@ int main(void)
 
   // 4. Generate Proof
   size_t proof_len = secp256k1_mpt_proof_equality_shared_r_size(N_RECIPIENTS);
-  unsigned char proof[proof_len];
+  unsigned char *proof = malloc(proof_len);
+  EXPECT(proof != NULL);
 
   int res = secp256k1_mpt_prove_equality_shared_r(
       ctx, proof, amount, r, N_RECIPIENTS, &C1, C2s, pks, tx_context);
@@ -111,6 +112,7 @@ int main(void)
   /* ---------------------------------------------------------------- */
 
   printf("Test passed!\n");
+  free(proof);
   secp256k1_context_destroy(ctx);
   return 0;
 }


### PR DESCRIPTION
Add `.github/workflows/build-shared-libs.yml`, a workflow that builds mpt-crypto as a shared library (`.dylib` / `.so` / `.dll`) for macOS (arm64, x86_64), Linux (arm64, x86_64, s390x), and Windows (x86_64), and attaches a single combined tarball to the corresponding GitHub release.

Downstream client libraries — xrpl4j (via JNA) and xrpl-py (via ctypes), and any future Rust/Go wrappers — need prebuilt mpt-crypto binaries they can load at runtime. Without this workflow, each consumer has to build mpt-crypto from source, which means every consumer repeats the Conan/CMake/OpenSSL/secp256k1 setup on its own CI. This workflow centralizes that work here.