### PR TITLE
Use XRPLF heavy runners

### DIFF
--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -94,15 +94,11 @@ jobs:
         with:
           platforms: ${{ matrix.docker_platform }}
 
-      - name: Set up Python
+      - name: Prepare runner
         if: matrix.docker_platform == ''
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: XRPLF/actions/prepare-runner@2cbf481018d930656e9276fcc20dc0e3a0be5b6d
         with:
-          python-version: "3.12"
-
-      - name: Install Conan and Ninja
-        if: matrix.docker_platform == ''
-        run: pip install conan ninja
+          enable_ccache: false
 
       - name: Build and test
         if: matrix.docker_platform == ''

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         include:
           # ── macOS ARM64 (Apple Silicon) ──
-          - os: macos-14
+          - os: macos15
             platform: darwin-aarch64
             lib_filename: libmpt-crypto.dylib
 
@@ -89,13 +89,24 @@ jobs:
     container: ${{ matrix.container != '' && fromJson(matrix.container) || null }}
 
     steps:
+      - name: Cleanup workspace
+        if: matrix.os == 'macos15'
+        uses: XRPLF/actions/cleanup-workspace@c7d9ce5ebb03c752a354889ecd870cadfc2b1cd4
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Set up QEMU
+      - name: Register QEMU binfmt handlers
         if: matrix.docker_platform != ''
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
-        with:
-          platforms: ${{ matrix.docker_platform }}
+        run: |
+          PLATFORM='${{ matrix.docker_platform }}'
+          ARCH="${PLATFORM##*/}"
+          docker run --rm --privileged tonistiigi/binfmt:latest --install "${ARCH}"
+          if [ ! -f "/proc/sys/fs/binfmt_misc/qemu-${ARCH}" ]; then
+            echo "ERROR: qemu-${ARCH} binfmt handler not registered"
+            ls /proc/sys/fs/binfmt_misc/ 2>&1 || true
+            exit 1
+          fi
+          echo "qemu-${ARCH} binfmt handler registered"
 
       - name: Prepare runner
         if: matrix.docker_platform == ''

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -62,24 +62,24 @@ jobs:
             lib_filename: libmpt-crypto.dylib
 
           # ── Linux ARM64 ──
-          - os: ubuntu-24.04-arm
+          - os: heavy-arm64
             platform: linux-aarch64
             lib_filename: libmpt-crypto.so
 
           # ── Linux x86_64 ──
-          - os: ubuntu-latest
+          - os: heavy
             platform: linux-x86-64
             lib_filename: libmpt-crypto.so
 
           # ── Linux s390x (IBM Z) — built via QEMU user-mode emulation ──
-          - os: ubuntu-latest
+          - os: heavy
             platform: linux-s390x
             lib_filename: libmpt-crypto.so
             docker_platform: linux/s390x
             docker_image: s390x/ubuntu:24.04
 
           # ── Windows x86_64 ──
-          - os: windows-latest
+          - os: windows
             platform: win32-x86-64
             lib_filename: mpt-crypto.dll
 
@@ -103,10 +103,6 @@ jobs:
       - name: Install Conan and Ninja
         if: matrix.docker_platform == ''
         run: pip install conan ninja
-
-      - name: Set up MSVC environment
-        if: runner.os == 'Windows'
-        uses: ilammy/msvc-dev-cmd@a102174a2b586eec2ea151a69e6fd14404a8ce7c # v1.13.0
 
       - name: Build and test
         if: matrix.docker_platform == ''

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -65,11 +65,13 @@ jobs:
           - os: heavy-arm64
             platform: linux-aarch64
             lib_filename: libmpt-crypto.so
+            container: '{ "image": "ghcr.io/xrplf/clio-ci:14342e087ceb8b593027198bf9ef06a43833c696" }'
 
           # ── Linux x86_64 ──
           - os: heavy
             platform: linux-x86-64
             lib_filename: libmpt-crypto.so
+            container: '{ "image": "ghcr.io/xrplf/clio-ci:14342e087ceb8b593027198bf9ef06a43833c696" }'
 
           # ── Linux s390x (IBM Z) — built via QEMU user-mode emulation ──
           - os: heavy
@@ -84,6 +86,7 @@ jobs:
             lib_filename: mpt-crypto.dll
 
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container != '' && fromJson(matrix.container) || null }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/build-shared-libs.yml
+++ b/.github/workflows/build-shared-libs.yml
@@ -74,7 +74,7 @@ jobs:
             container: '{ "image": "ghcr.io/xrplf/clio-ci:14342e087ceb8b593027198bf9ef06a43833c696" }'
 
           # ── Linux s390x (IBM Z) — built via QEMU user-mode emulation ──
-          - os: heavy
+          - os: ubuntu-latest
             platform: linux-s390x
             lib_filename: libmpt-crypto.so
             docker_platform: linux/s390x
@@ -95,18 +95,11 @@ jobs:
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Register QEMU binfmt handlers
+      - name: Set up QEMU
         if: matrix.docker_platform != ''
-        run: |
-          PLATFORM='${{ matrix.docker_platform }}'
-          ARCH="${PLATFORM##*/}"
-          docker run --rm --privileged tonistiigi/binfmt:latest --install "${ARCH}"
-          if [ ! -f "/proc/sys/fs/binfmt_misc/qemu-${ARCH}" ]; then
-            echo "ERROR: qemu-${ARCH} binfmt handler not registered"
-            ls /proc/sys/fs/binfmt_misc/ 2>&1 || true
-            exit 1
-          fi
-          echo "qemu-${ARCH} binfmt handler registered"
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+        with:
+          platforms: ${{ matrix.docker_platform }}
 
       - name: Prepare runner
         if: matrix.docker_platform == ''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,7 @@ jobs:
   # the reusable workflow.
   native-binaries:
     name: Build native shared libraries
+    if: github.repository_owner == 'XRPLF'
     permissions:
       contents: read
     uses: ./.github/workflows/build-shared-libs.yml


### PR DESCRIPTION
## Changes
- Use heavy / heavy-arm64 for Linux builds (inside the `clio-ci` container, matching `build-and-test`)
- Use macos15 for macOS arm64 builds
- Use windows runner for Windows builds; remove explicit MSVC environment setup (`ilammy/msvc-dev-cmd`)
- Replace setup-python + pip install with `XRPLF/actions/prepare-runner`
- Add `Cleanup workspace` step for the persistent macos15 runner
- Skip `native-binaries` on forks (matches `build-and-test`'s pattern)

## Still on GHA-hosted runners
- **macOS Intel** (`macos-15-intel`) — no XRPLF Intel runner available
- **Linux s390x** (`ubuntu-latest`) — QEMU setup needs privileged binfmt registration, which heavy doesn't allow.
