### PR TITLE
fix: make compute_sigma_response infallible on zero witness

### DIFF
--- a/src/mpt_internal.h
+++ b/src/mpt_internal.h
@@ -29,9 +29,13 @@
             return 0;       \
     } while (0)
 
-/* Forward-declare secp256k1_mpt helpers used in nonce generation. */
+/* Forward-declare secp256k1_mpt scalar helpers. */
 void
 secp256k1_mpt_scalar_reduce32(unsigned char out32[32], unsigned char const in32[32]);
+void
+secp256k1_mpt_scalar_add(unsigned char* res, unsigned char const* a, unsigned char const* b);
+void
+secp256k1_mpt_scalar_mul(unsigned char* res, unsigned char const* a, unsigned char const* b);
 
 /** Returns 1 if pk1 == pk2, 0 otherwise. */
 static inline int
@@ -89,30 +93,29 @@ compute_amount_point(secp256k1_context const* ctx, secp256k1_pubkey* mG, uint64_
 }
 
 /** Compute a sigma-protocol response: z = nonce + e * secret (mod order).
- *  Cleanses the intermediate product. Returns 1 on success, 0 on failure. */
-static inline int
+ *
+ *  Uses direct scalar-field arithmetic rather than
+ *  secp256k1_ec_seckey_tweak_mul/add, which reject zero operands via
+ *  seckey_verify. Zero secrets occur with probability 1 in legitimate
+ *  states (e.g. amount=0 or balance=0 inputs to compact sigma proofs),
+ *  so the sigma-response computation must not abort on them.
+ *
+ *  The output z is a response scalar (nonce + e*secret) that is
+ *  transmitted in the proof; 0 is a cryptographically negligible output
+ *  given random nonce. Hence no failure mode: the function is void.
+ *
+ *  Cleanses the intermediate product. */
+static inline void
 compute_sigma_response(
-    secp256k1_context const* ctx,
     unsigned char* z_out,
     unsigned char const* nonce,
     unsigned char const* e,
     unsigned char const* secret)
 {
     unsigned char term[32];
-    memcpy(z_out, nonce, 32);
-    memcpy(term, secret, 32);
-    if (!secp256k1_ec_seckey_tweak_mul(ctx, term, e))
-    {
-        OPENSSL_cleanse(term, 32);
-        return 0;
-    }
-    if (!secp256k1_ec_seckey_tweak_add(ctx, z_out, term))
-    {
-        OPENSSL_cleanse(term, 32);
-        return 0;
-    }
+    secp256k1_mpt_scalar_mul(term, e, secret);
+    secp256k1_mpt_scalar_add(z_out, nonce, term);
     OPENSSL_cleanse(term, 32);
-    return 1;
 }
 
 /**

--- a/src/proof_compact_clawback.c
+++ b/src/proof_compact_clawback.c
@@ -207,8 +207,7 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
     goto cleanup;
 
   /* 4. Response: z_sk = t_sk + e*sk_iss */
-  if (!compute_sigma_response(ctx, z_sk, t_sk, e, sk_iss))
-    goto cleanup;
+  compute_sigma_response(z_sk, t_sk, e, sk_iss);
 
   /* 5. Serialize: e || z_sk */
   memcpy(proof_out, e, 32);

--- a/src/proof_compact_convertback.c
+++ b/src/proof_compact_convertback.c
@@ -241,12 +241,9 @@ int secp256k1_compact_convertback_prove(
     goto cleanup;
 
   /* 4. Responses */
-  if (!compute_sigma_response(ctx, z_b, t_b, e, b_scalar))
-    goto cleanup;
-  if (!compute_sigma_response(ctx, z_sk, t_sk, e, sk_A))
-    goto cleanup;
-  if (!compute_sigma_response(ctx, z_rho, t_rho, e, rho))
-    goto cleanup;
+  compute_sigma_response(z_b, t_b, e, b_scalar);
+  compute_sigma_response(z_sk, t_sk, e, sk_A);
+  compute_sigma_response(z_rho, t_rho, e, rho);
 
   /* 5. Serialize: e || z_b || z_rho || z_sk */
   memcpy(proof_out, e, 32);

--- a/src/proof_compact_standard.c
+++ b/src/proof_compact_standard.c
@@ -341,20 +341,15 @@ int secp256k1_compact_standard_prove(
   /* 4. Responses */
 
   /* z_r = alpha + e*r */
-  if (!compute_sigma_response(ctx, z_r, alpha, e, r_shared))
-    goto cleanup;
+  compute_sigma_response(z_r, alpha, e, r_shared);
   /* z_m = beta + e*m */
-  if (!compute_sigma_response(ctx, z_m, beta, e, m_scalar))
-    goto cleanup;
+  compute_sigma_response(z_m, beta, e, m_scalar);
   /* z_sk = gamma + e*sk_A */
-  if (!compute_sigma_response(ctx, z_sk, gamma, e, sk_A))
-    goto cleanup;
+  compute_sigma_response(z_sk, gamma, e, sk_A);
   /* z_rb = delta + e*r_b */
-  if (!compute_sigma_response(ctx, z_rb, delta, e, r_b))
-    goto cleanup;
+  compute_sigma_response(z_rb, delta, e, r_b);
   /* z_b = epsilon + e*v */
-  if (!compute_sigma_response(ctx, z_b, epsilon, e, b_scalar))
-    goto cleanup;
+  compute_sigma_response(z_b, epsilon, e, b_scalar);
 
   /* 5. Serialize compact proof: e || z_m || z_r || z_b || z_rho || z_sk */
   memcpy(proof_out, e, 32);

--- a/src/proof_pok_sk.c
+++ b/src/proof_pok_sk.c
@@ -150,8 +150,7 @@ int secp256k1_mpt_pok_sk_prove(const secp256k1_context *ctx,
     goto cleanup;
 
   /* 4. Response: s = k + e*sk */
-  if (!compute_sigma_response(ctx, s, k, e, sk))
-    goto cleanup;
+  compute_sigma_response(s, k, e, sk);
 
   /* 5. Serialize: e || s */
   memcpy(proof_out, e, 32);

--- a/tests/test_bulletproof_agg.c
+++ b/tests/test_bulletproof_agg.c
@@ -102,7 +102,12 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
            total_ms / VERIFY_RUNS);
   }
 
-  /* ---- Negative Test (Tamper) ---- */
+  /* ---- Negative Test A: tampered value ----
+   * Creates a fake commitment to (value ± 1) in the last slot and verifies the
+   * proof still rejects. The explicit `ok == 0` assertion addresses the ToB
+   * fix-review caveat (April 2026, p. 66): negative-path tests should assert
+   * a specific return code for the unavoidable-infinity paths triggered by
+   * value=0 and value=UINT64_MAX, not just absence of crash. */
   secp256k1_pubkey *bad_commitments =
       malloc(num_values * sizeof(*bad_commitments));
   EXPECT(bad_commitments != NULL);
@@ -111,7 +116,8 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
   unsigned char bad_blinding[32];
   random_scalar(ctx, bad_blinding);
 
-  /* Create fake commitment to (value + 1) */
+  /* Create fake commitment to (value + 1), or (value - 1) when value =
+   * UINT64_MAX. */
   EXPECT(secp256k1_bulletproof_create_commitment(
       ctx, &bad_commitments[num_values - 1],
       (values[num_values - 1] == UINT64_MAX) ? values[num_values - 1] - 1
@@ -121,13 +127,30 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
   ok = secp256k1_bulletproof_verify_agg(ctx, G_vec, H_vec, proof, proof_len,
                                         bad_commitments, num_values, &pk_base,
                                         context_id);
+  EXPECT(ok == 0);
+  printf("  PASSED (Rejected tampered-value proof)\n");
 
-  if (ok)
+  /* ---- Negative Test B: same value, different blinding ----
+   * Replaces the last commitment with a commitment to the SAME value but a
+   * fresh blinding factor. The verifier should reject with return code 0,
+   * exercising the rejection path even when the value witness itself is 0
+   * (i.e. no G-term was included in the original commitment). */
+  memcpy(bad_commitments, commitments, sizeof(*commitments) * num_values);
+  unsigned char alt_blinding[32];
+  do
   {
-    fprintf(stderr, "FAILED: Accepted invalid proof!\n");
-    exit(EXIT_FAILURE);
-  }
-  printf("  PASSED (Rejected invalid proof)\n");
+    random_scalar(ctx, alt_blinding);
+  } while (memcmp(alt_blinding, blindings[num_values - 1], 32) == 0);
+
+  EXPECT(secp256k1_bulletproof_create_commitment(
+      ctx, &bad_commitments[num_values - 1], values[num_values - 1],
+      alt_blinding, &pk_base));
+
+  ok = secp256k1_bulletproof_verify_agg(ctx, G_vec, H_vec, proof, proof_len,
+                                        bad_commitments, num_values, &pk_base,
+                                        context_id);
+  EXPECT(ok == 0);
+  printf("  PASSED (Rejected same-value/different-blinding proof)\n");
 
   free(bad_commitments);
   free(commitments);

--- a/tests/test_compact_convertback.c
+++ b/tests/test_compact_convertback.c
@@ -4,6 +4,155 @@
 #include <stdio.h>
 #include <string.h>
 
+/* Exercise the ConvertBack prove/verify path end-to-end for a given balance.
+ * When balance == 0, B2 omits the balance*G term (paper convention:
+ * libsecp256k1 cannot represent the point at infinity). Runs the full
+ * negative-path battery only for the primary case.
+ */
+static void run_convertback_case(const secp256k1_context *ctx, uint64_t balance,
+                                 int run_negative_tests, const char *label)
+{
+  /* Withdrawal is distinct from balance; the ConvertBack proof only binds
+   * balance (via B1/B2/PC_b). We pick a withdrawal just to exercise the
+   * auxiliary encryption check when balance > 0. */
+  const uint64_t withdrawal = (balance == 0) ? 0 : 250000;
+
+  printf("\n--- %s (balance=%llu) ---\n", label, (unsigned long long)balance);
+
+  unsigned char r_w[32], r_bal[32], sk_A[32], rho[32], context_id[32];
+  secp256k1_pubkey pk_A, H;
+
+  random_scalar(ctx, r_w);
+  random_scalar(ctx, r_bal);
+  random_scalar(ctx, sk_A);
+  random_scalar(ctx, rho);
+  random_bytes(context_id);
+
+  EXPECT(secp256k1_ec_pubkey_create(ctx, &pk_A, sk_A));
+  EXPECT(secp256k1_mpt_get_h_generator(ctx, &H));
+
+  /* Withdrawal ciphertext: C1_w = r_w*G, C2_w = m*G + r_w*P_A
+   * (skip m*G when withdrawal = 0). */
+  secp256k1_pubkey C1_w, C2_w;
+  EXPECT(secp256k1_ec_pubkey_create(ctx, &C1_w, r_w));
+  {
+    secp256k1_pubkey rwPA = pk_A;
+    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rwPA, r_w));
+    secp256k1_pubkey mG;
+    if (value_times_g(ctx, &mG, withdrawal))
+    {
+      const secp256k1_pubkey *pts[2] = {&mG, &rwPA};
+      EXPECT(secp256k1_ec_pubkey_combine(ctx, &C2_w, pts, 2));
+    }
+    else
+    {
+      C2_w = rwPA;
+    }
+  }
+
+  /* Skip the deterministic ciphertext sanity check for withdrawal=0
+   * (elgamal_verify_encryption's internal handling of m=0 is out of
+   * scope for this test). */
+  if (withdrawal > 0)
+  {
+    EXPECT(secp256k1_elgamal_verify_encryption(ctx, &C1_w, &C2_w, &pk_A,
+                                               withdrawal, r_w));
+  }
+
+  /* On-ledger balance ciphertext: B1 = r_bal*G,
+   * B2 = balance*G + r_bal*P_A (skip balance*G when balance = 0). */
+  secp256k1_pubkey B1, B2;
+  EXPECT(secp256k1_ec_pubkey_create(ctx, &B1, r_bal));
+  {
+    secp256k1_pubkey rbalPA = pk_A;
+    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rbalPA, r_bal));
+    secp256k1_pubkey balG;
+    if (value_times_g(ctx, &balG, balance))
+    {
+      const secp256k1_pubkey *pts[2] = {&balG, &rbalPA};
+      EXPECT(secp256k1_ec_pubkey_combine(ctx, &B2, pts, 2));
+    }
+    else
+    {
+      B2 = rbalPA;
+    }
+  }
+
+  /* PC_b = balance*G + rho*H (secp256k1_mpt_pedersen_commit handles
+   * balance=0 internally). */
+  secp256k1_pubkey PC_b;
+  EXPECT(secp256k1_mpt_pedersen_commit(ctx, &PC_b, balance, rho));
+
+  /* Positive case */
+  unsigned char proof[SECP256K1_COMPACT_CONVERTBACK_PROOF_SIZE];
+  int res = secp256k1_compact_convertback_prove(
+      ctx, proof, balance, sk_A, rho, &pk_A, &B1, &B2, &PC_b, context_id);
+  EXPECT(res == 1);
+
+  res = secp256k1_compact_convertback_verify(ctx, proof, &pk_A, &B1, &B2, &PC_b,
+                                             context_id);
+  EXPECT(res == 1);
+  printf("  prove + verify OK.\n");
+
+  if (!run_negative_tests)
+    return;
+
+  /* Negative: Wrong context */
+  {
+    unsigned char fake_ctx[32];
+    memcpy(fake_ctx, context_id, 32);
+    fake_ctx[0] ^= 0xFF;
+    res = secp256k1_compact_convertback_verify(ctx, proof, &pk_A, &B1, &B2,
+                                               &PC_b, fake_ctx);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Corrupted proof byte */
+  {
+    unsigned char bad[SECP256K1_COMPACT_CONVERTBACK_PROOF_SIZE];
+    memcpy(bad, proof, SECP256K1_COMPACT_CONVERTBACK_PROOF_SIZE);
+    bad[SECP256K1_COMPACT_CONVERTBACK_PROOF_SIZE - 1] ^= 0x01;
+    res = secp256k1_compact_convertback_verify(ctx, bad, &pk_A, &B1, &B2, &PC_b,
+                                               context_id);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Wrong PC_b */
+  {
+    secp256k1_pubkey PC_b_bad;
+    unsigned char bad_rho[32];
+    random_scalar(ctx, bad_rho);
+    EXPECT(secp256k1_mpt_pedersen_commit(ctx, &PC_b_bad, balance, bad_rho));
+    res = secp256k1_compact_convertback_verify(ctx, proof, &pk_A, &B1, &B2,
+                                               &PC_b_bad, context_id);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Tampered B2 */
+  {
+    secp256k1_pubkey B2_bad = B2;
+    unsigned char tweak[32] = {0};
+    tweak[31] = 1;
+    EXPECT(secp256k1_ec_pubkey_tweak_add(ctx, &B2_bad, tweak));
+    res = secp256k1_compact_convertback_verify(ctx, proof, &pk_A, &B1, &B2_bad,
+                                               &PC_b, context_id);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Wrong pk_A */
+  {
+    unsigned char sk_bad[32];
+    secp256k1_pubkey pk_bad;
+    random_scalar(ctx, sk_bad);
+    EXPECT(secp256k1_ec_pubkey_create(ctx, &pk_bad, sk_bad));
+    res = secp256k1_compact_convertback_verify(ctx, proof, &pk_bad, &B1, &B2,
+                                               &PC_b, context_id);
+    EXPECT(res == 0);
+  }
+
+  printf("  negative-path checks OK.\n");
+}
+
 int main(void)
 {
   secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN |
@@ -16,162 +165,17 @@ int main(void)
 
   printf("=== Running Test: Compact ConvertBack Proof (128 bytes) ===\n");
 
-  uint64_t balance = 1000000;
-  uint64_t withdrawal = 250000;
+  /* Primary case. */
+  run_convertback_case(ctx, /*balance=*/1000000, /*run_negative_tests=*/1,
+                       "primary");
 
-  unsigned char r_w[32], r_bal[32], sk_A[32], rho[32], context_id[32];
-  secp256k1_pubkey pk_A, H;
-
-  random_scalar(ctx, r_w);
-  random_scalar(ctx, r_bal);
-  random_scalar(ctx, sk_A);
-  random_scalar(ctx, rho);
-  random_scalar(ctx, context_id);
-
-  EXPECT(secp256k1_ec_pubkey_create(ctx, &pk_A, sk_A));
-  EXPECT(secp256k1_mpt_get_h_generator(ctx, &H));
-
-  /* Withdrawal ciphertext: C1_w = r_w*G, C2_w = m*G + r_w*P_A */
-  secp256k1_pubkey C1_w, C2_w;
-  EXPECT(secp256k1_ec_pubkey_create(ctx, &C1_w, r_w));
-  {
-    unsigned char m_scalar[32] = {0};
-    for (int b = 0; b < 8; b++)
-      m_scalar[31 - b] = (withdrawal >> (b * 8)) & 0xFF;
-    secp256k1_pubkey mG, rwPA;
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &mG, m_scalar));
-    rwPA = pk_A;
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rwPA, r_w));
-    const secp256k1_pubkey *pts[2] = {&mG, &rwPA};
-    EXPECT(secp256k1_ec_pubkey_combine(ctx, &C2_w, pts, 2));
-  }
-
-  /* Deterministic ciphertext verification (simulates what verifier does
-   * with disclosed r_w): */
-  EXPECT(secp256k1_elgamal_verify_encryption(ctx, &C1_w, &C2_w, &pk_A,
-                                             withdrawal, r_w));
-  printf("Deterministic ciphertext verification OK.\n");
-
-  /* On-ledger balance ciphertext: B1 = r_bal*G, B2 = balance*G + r_bal*P_A */
-  secp256k1_pubkey B1, B2;
-  EXPECT(secp256k1_ec_pubkey_create(ctx, &B1, r_bal));
-  {
-    unsigned char bal_scalar[32] = {0};
-    for (int b = 0; b < 8; b++)
-      bal_scalar[31 - b] = (balance >> (b * 8)) & 0xFF;
-    secp256k1_pubkey balG, rbalPA;
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &balG, bal_scalar));
-    rbalPA = pk_A;
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rbalPA, r_bal));
-    const secp256k1_pubkey *pts[2] = {&balG, &rbalPA};
-    EXPECT(secp256k1_ec_pubkey_combine(ctx, &B2, pts, 2));
-  }
-
-  /* PC_b = balance*G + rho*H */
-  secp256k1_pubkey PC_b;
-  EXPECT(secp256k1_mpt_pedersen_commit(ctx, &PC_b, balance, rho));
-
-  /* Verify relation: B2 - balance*G = sk_A*B1 */
-  {
-    unsigned char bal_scalar[32] = {0};
-    for (int b = 0; b < 8; b++)
-      bal_scalar[31 - b] = (balance >> (b * 8)) & 0xFF;
-    secp256k1_pubkey balG, skB1;
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &balG, bal_scalar));
-    unsigned char neg_one[32];
-    unsigned char one[32] = {0};
-    one[31] = 1;
-    secp256k1_mpt_scalar_negate(neg_one, one);
-    secp256k1_pubkey neg_balG = balG;
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &neg_balG, neg_one));
-    secp256k1_pubkey lhs;
-    const secp256k1_pubkey *sub_pts[2] = {&B2, &neg_balG};
-    EXPECT(secp256k1_ec_pubkey_combine(ctx, &lhs, sub_pts, 2));
-    skB1 = B1;
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &skB1, sk_A));
-    EXPECT(secp256k1_ec_pubkey_cmp(ctx, &lhs, &skB1) == 0);
-    printf("Balance decryption relation verified.\n");
-  }
-
-  /* --- Positive Case --- */
-  printf("Generating compact convertback proof...\n");
-
-  unsigned char proof[SECP256K1_COMPACT_CONVERTBACK_PROOF_SIZE];
-  int res = secp256k1_compact_convertback_prove(
-      ctx, proof, balance, sk_A, rho, &pk_A, &B1, &B2, &PC_b, context_id);
-  EXPECT(res == 1);
-  printf("Proof generated: %d bytes.\n",
-         SECP256K1_COMPACT_CONVERTBACK_PROOF_SIZE);
-
-  res = secp256k1_compact_convertback_verify(ctx, proof, &pk_A, &B1, &B2, &PC_b,
-                                             context_id);
-  EXPECT(res == 1);
-  printf("Proof verified successfully.\n");
-
-  /* --- Negative: Wrong context --- */
-  printf("Testing wrong context...\n");
-  {
-    unsigned char fake_ctx[32];
-    memcpy(fake_ctx, context_id, 32);
-    fake_ctx[0] ^= 0xFF;
-    res = secp256k1_compact_convertback_verify(ctx, proof, &pk_A, &B1, &B2,
-                                               &PC_b, fake_ctx);
-    EXPECT(res == 0);
-  }
-  printf("Wrong context: rejected OK.\n");
-
-  /* --- Negative: Corrupted proof byte --- */
-  printf("Testing corrupted proof...\n");
-  {
-    unsigned char bad[SECP256K1_COMPACT_CONVERTBACK_PROOF_SIZE];
-    memcpy(bad, proof, SECP256K1_COMPACT_CONVERTBACK_PROOF_SIZE);
-    bad[SECP256K1_COMPACT_CONVERTBACK_PROOF_SIZE - 1] ^= 0x01;
-    res = secp256k1_compact_convertback_verify(ctx, bad, &pk_A, &B1, &B2, &PC_b,
-                                               context_id);
-    EXPECT(res == 0);
-  }
-  printf("Corrupted proof: rejected OK.\n");
-
-  /* --- Negative: Wrong PC_b --- */
-  printf("Testing wrong PC_b...\n");
-  {
-    secp256k1_pubkey PC_b_bad;
-    unsigned char bad_rho[32];
-    random_scalar(ctx, bad_rho);
-    EXPECT(secp256k1_mpt_pedersen_commit(ctx, &PC_b_bad, balance, bad_rho));
-    res = secp256k1_compact_convertback_verify(ctx, proof, &pk_A, &B1, &B2,
-                                               &PC_b_bad, context_id);
-    EXPECT(res == 0);
-  }
-  printf("Wrong PC_b: rejected OK.\n");
-
-  /* --- Negative: Wrong B2 (tampered balance ciphertext) --- */
-  printf("Testing tampered B2...\n");
-  {
-    secp256k1_pubkey B2_bad = B2;
-    unsigned char tweak[32] = {0};
-    tweak[31] = 1;
-    EXPECT(secp256k1_ec_pubkey_tweak_add(ctx, &B2_bad, tweak));
-    res = secp256k1_compact_convertback_verify(ctx, proof, &pk_A, &B1, &B2_bad,
-                                               &PC_b, context_id);
-    EXPECT(res == 0);
-  }
-  printf("Tampered B2: rejected OK.\n");
-
-  /* --- Negative: Wrong pk_A --- */
-  printf("Testing wrong pk_A...\n");
-  {
-    unsigned char sk_bad[32];
-    secp256k1_pubkey pk_bad;
-    random_scalar(ctx, sk_bad);
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &pk_bad, sk_bad));
-    res = secp256k1_compact_convertback_verify(ctx, proof, &pk_bad, &B1, &B2,
-                                               &PC_b, context_id);
-    EXPECT(res == 0);
-  }
-  printf("Wrong pk_A: rejected OK.\n");
+  /* Zero-balance case: exercises the zero-witness path in
+   * compute_sigma_response for z_b, and the omitted-balance*G term in
+   * B2 and PC_b. Tracks issue #38. */
+  run_convertback_case(ctx, /*balance=*/0, /*run_negative_tests=*/0,
+                       "zero balance");
 
   secp256k1_context_destroy(ctx);
-  printf("ALL COMPACT CONVERTBACK TESTS PASSED\n");
+  printf("\nALL COMPACT CONVERTBACK TESTS PASSED\n");
   return 0;
 }

--- a/tests/test_compact_standard.c
+++ b/tests/test_compact_standard.c
@@ -5,6 +5,232 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Build C1 = r*G, C2_i = r*pk_i + m*G (term skipped when m == 0), PC_m = m*G +
+ * r*H (m*G term skipped when m == 0), PC_b = v*G + r_b*H (v*G term skipped when
+ * v == 0), B1/B2 from the remainder-ciphertext subtraction. Runs the full
+ * prove/verify flow plus optional negative-path assertions.
+ */
+static void run_compact_standard_case(const secp256k1_context *ctx,
+                                      uint64_t amount, uint64_t balance,
+                                      int run_negative_tests, const char *label)
+{
+  EXPECT(balance >= amount);
+  const uint64_t remainder = balance - amount;
+  const int N = 3;
+
+  printf("\n--- %s (amount=%llu, balance=%llu, remainder=%llu) ---\n", label,
+         (unsigned long long)amount, (unsigned long long)balance,
+         (unsigned long long)remainder);
+
+  unsigned char r[32], r_bal[32], r_b[32], sk_A[32], context_id[32];
+  secp256k1_pubkey pk_A, H;
+
+  random_scalar(ctx, r);
+  random_scalar(ctx, r_bal);
+  random_scalar(ctx, r_b);
+  random_scalar(ctx, sk_A);
+  random_bytes(context_id);
+
+  EXPECT(secp256k1_ec_pubkey_create(ctx, &pk_A, sk_A));
+  EXPECT(secp256k1_mpt_get_h_generator(ctx, &H));
+
+  /* Recipient keys */
+  unsigned char sk_recip[3][32];
+  secp256k1_pubkey pks[3];
+  for (int i = 0; i < N; i++)
+  {
+    random_scalar(ctx, sk_recip[i]);
+    EXPECT(secp256k1_ec_pubkey_create(ctx, &pks[i], sk_recip[i]));
+  }
+
+  /* C1 = r*G */
+  secp256k1_pubkey C1;
+  EXPECT(secp256k1_ec_pubkey_create(ctx, &C1, r));
+
+  /* m*G, if m > 0 */
+  secp256k1_pubkey mG;
+  const int has_mG = value_times_g(ctx, &mG, amount);
+
+  /* C2_i = r*pk_i + m*G (skip m*G when amount=0) */
+  secp256k1_pubkey C2_vec[3];
+  for (int i = 0; i < N; i++)
+  {
+    secp256k1_pubkey rPk = pks[i];
+    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rPk, r));
+    if (has_mG)
+    {
+      const secp256k1_pubkey *pts[2] = {&rPk, &mG};
+      EXPECT(secp256k1_ec_pubkey_combine(ctx, &C2_vec[i], pts, 2));
+    }
+    else
+    {
+      C2_vec[i] = rPk;
+    }
+  }
+
+  /* PC_m = m*G + r*H (skip m*G when amount=0) */
+  secp256k1_pubkey PC_m;
+  {
+    secp256k1_pubkey rH = H;
+    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rH, r));
+    if (has_mG)
+    {
+      const secp256k1_pubkey *pts[2] = {&mG, &rH};
+      EXPECT(secp256k1_ec_pubkey_combine(ctx, &PC_m, pts, 2));
+    }
+    else
+    {
+      PC_m = rH;
+    }
+  }
+
+  /* PC_b = v*G + r_b*H (skip v*G when remainder=0) */
+  secp256k1_pubkey PC_b;
+  {
+    secp256k1_pubkey vG;
+    const int has_vG = value_times_g(ctx, &vG, remainder);
+    secp256k1_pubkey rbH = H;
+    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rbH, r_b));
+    if (has_vG)
+    {
+      const secp256k1_pubkey *pts[2] = {&vG, &rbH};
+      EXPECT(secp256k1_ec_pubkey_combine(ctx, &PC_b, pts, 2));
+    }
+    else
+    {
+      PC_b = rbH;
+    }
+  }
+
+  /* r_diff = r_bal - r (mod n); must be non-zero so B1 is a valid point. */
+  unsigned char r_diff[32];
+  {
+    unsigned char neg_r[32];
+    secp256k1_mpt_scalar_negate(neg_r, r);
+    secp256k1_mpt_scalar_add(r_diff, r_bal, neg_r);
+    secp256k1_mpt_scalar_reduce32(r_diff, r_diff);
+    EXPECT(secp256k1_ec_seckey_verify(ctx, r_diff));
+  }
+
+  /* B1 = r_diff*G */
+  secp256k1_pubkey B1;
+  EXPECT(secp256k1_ec_pubkey_create(ctx, &B1, r_diff));
+
+  /* B2 = r_diff*pk_A + v*G (skip v*G when remainder=0) */
+  secp256k1_pubkey B2;
+  {
+    secp256k1_pubkey rdPk = pk_A;
+    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rdPk, r_diff));
+    secp256k1_pubkey vG;
+    const int has_vG = value_times_g(ctx, &vG, remainder);
+    if (has_vG)
+    {
+      const secp256k1_pubkey *pts[2] = {&rdPk, &vG};
+      EXPECT(secp256k1_ec_pubkey_combine(ctx, &B2, pts, 2));
+    }
+    else
+    {
+      B2 = rdPk;
+    }
+  }
+
+  /* Sanity: Variant B relation holds: sk_A*B1 + v*G == B2 (v*G skipped when 0).
+   */
+  {
+    secp256k1_pubkey skB1 = B1, check;
+    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &skB1, sk_A));
+    secp256k1_pubkey vG;
+    const int has_vG = value_times_g(ctx, &vG, remainder);
+    if (has_vG)
+    {
+      const secp256k1_pubkey *pts[2] = {&skB1, &vG};
+      EXPECT(secp256k1_ec_pubkey_combine(ctx, &check, pts, 2));
+    }
+    else
+    {
+      check = skB1;
+    }
+    EXPECT(secp256k1_ec_pubkey_cmp(ctx, &check, &B2) == 0);
+  }
+
+  /* Positive case */
+  unsigned char proof[SECP256K1_COMPACT_STANDARD_PROOF_SIZE];
+  int res = secp256k1_compact_standard_prove(
+      ctx, proof, amount, remainder, r, sk_A, r_b, N, &C1, C2_vec, pks, &PC_m,
+      &pk_A, &PC_b, &B1, &B2, context_id);
+  EXPECT(res == 1);
+
+  res =
+      secp256k1_compact_standard_verify(ctx, proof, N, &C1, C2_vec, pks, &PC_m,
+                                        &pk_A, &PC_b, &B1, &B2, context_id);
+  EXPECT(res == 1);
+  printf("  prove + verify OK.\n");
+
+  if (!run_negative_tests)
+    return;
+
+  /* Negative: Wrong context */
+  {
+    unsigned char fake_ctx[32];
+    memcpy(fake_ctx, context_id, 32);
+    fake_ctx[0] ^= 0xFF;
+    res = secp256k1_compact_standard_verify(ctx, proof, N, &C1, C2_vec, pks,
+                                            &PC_m, &pk_A, &PC_b, &B1, &B2,
+                                            fake_ctx);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Tampered C1 */
+  {
+    secp256k1_pubkey C1_bad = C1;
+    unsigned char tweak[32] = {0};
+    tweak[31] = 1;
+    EXPECT(secp256k1_ec_pubkey_tweak_add(ctx, &C1_bad, tweak));
+    res = secp256k1_compact_standard_verify(ctx, proof, N, &C1_bad, C2_vec, pks,
+                                            &PC_m, &pk_A, &PC_b, &B1, &B2,
+                                            context_id);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Tampered C2_0 */
+  {
+    secp256k1_pubkey C2_bad[3];
+    memcpy(C2_bad, C2_vec, sizeof(C2_vec));
+    unsigned char tweak[32] = {0};
+    tweak[31] = 1;
+    EXPECT(secp256k1_ec_pubkey_tweak_add(ctx, &C2_bad[0], tweak));
+    res = secp256k1_compact_standard_verify(ctx, proof, N, &C1, C2_bad, pks,
+                                            &PC_m, &pk_A, &PC_b, &B1, &B2,
+                                            context_id);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Corrupted proof byte */
+  {
+    unsigned char bad[SECP256K1_COMPACT_STANDARD_PROOF_SIZE];
+    memcpy(bad, proof, SECP256K1_COMPACT_STANDARD_PROOF_SIZE);
+    bad[SECP256K1_COMPACT_STANDARD_PROOF_SIZE - 1] ^= 0x01;
+    res =
+        secp256k1_compact_standard_verify(ctx, bad, N, &C1, C2_vec, pks, &PC_m,
+                                          &pk_A, &PC_b, &B1, &B2, context_id);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Wrong PC_b */
+  {
+    secp256k1_pubkey PC_b_bad;
+    unsigned char bad_rb[32];
+    random_scalar(ctx, bad_rb);
+    EXPECT(secp256k1_ec_pubkey_create(ctx, &PC_b_bad, bad_rb));
+    res = secp256k1_compact_standard_verify(ctx, proof, N, &C1, C2_vec, pks,
+                                            &PC_m, &pk_A, &PC_b_bad, &B1, &B2,
+                                            context_id);
+    EXPECT(res == 0);
+  }
+
+  printf("  negative-path checks OK.\n");
+}
+
 int main(void)
 {
   secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN |
@@ -18,222 +244,23 @@ int main(void)
   printf(
       "=== Running Test: Compact AND-Composed Standard EC-ElGamal Proof ===\n");
 
-  const int N = 3;
-  uint64_t balance = 1000000;
-  uint64_t amount = 123456;
-  uint64_t remainder = balance - amount;
+  /* Primary case: non-zero amount, non-zero remainder. Runs full negatives. */
+  run_compact_standard_case(ctx, /*amount=*/123456, /*balance=*/1000000,
+                            /*run_negative_tests=*/1, "primary");
 
-  unsigned char r[32], r_bal[32], r_b[32], sk_A[32], context_id[32];
-  secp256k1_pubkey pk_A, H;
+  /* Zero-amount case (m = 0): exercises the zero-witness path in
+   * compute_sigma_response for z_m, and the omitted-G-term path for
+   * C2_i / PC_m. Tracks issue #38. */
+  run_compact_standard_case(ctx, /*amount=*/0, /*balance=*/1000000,
+                            /*run_negative_tests=*/0, "zero amount");
 
-  random_scalar(ctx, r);
-  random_scalar(ctx, r_bal);
-  random_scalar(ctx, r_b);
-  random_scalar(ctx, sk_A);
-  random_scalar(ctx, context_id);
-
-  EXPECT(secp256k1_ec_pubkey_create(ctx, &pk_A, sk_A));
-  EXPECT(secp256k1_mpt_get_h_generator(ctx, &H));
-
-  /* Generate recipient keys */
-  unsigned char sk_recip[3][32];
-  secp256k1_pubkey pks[3];
-  for (int i = 0; i < N; i++)
-  {
-    random_scalar(ctx, sk_recip[i]);
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &pks[i], sk_recip[i]));
-  }
-
-  /* Standard EG ciphertexts with shared r:
-   *   C1    = r*G
-   *   C2_i  = r*pk_i + m*G
-   *   PC_m  = r*G + m*H         (Pedersen commitment reusing r)
-   */
-  secp256k1_pubkey C1, C2_vec[3], PC_m;
-
-  /* C1 = r*G */
-  EXPECT(secp256k1_ec_pubkey_create(ctx, &C1, r));
-
-  /* m*G */
-  secp256k1_pubkey mG;
-  {
-    unsigned char m_scalar[32] = {0};
-    for (int b = 0; b < 8; b++)
-      m_scalar[31 - b] = (amount >> (b * 8)) & 0xFF;
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &mG, m_scalar));
-  }
-
-  /* C2_i = r*pk_i + m*G */
-  for (int i = 0; i < N; i++)
-  {
-    secp256k1_pubkey rPk = pks[i];
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rPk, r));
-    const secp256k1_pubkey *pts[2] = {&rPk, &mG};
-    EXPECT(secp256k1_ec_pubkey_combine(ctx, &C2_vec[i], pts, 2));
-  }
-
-  /* PC_m = m*G + r*H  (paper convention: value on G, blinding on H) */
-  {
-    secp256k1_pubkey mG_pc, rH;
-    unsigned char m_scalar[32] = {0};
-    for (int b = 0; b < 8; b++)
-      m_scalar[31 - b] = (amount >> (b * 8)) & 0xFF;
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &mG_pc, m_scalar));
-    rH = H;
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rH, r));
-    const secp256k1_pubkey *pts[2] = {&mG_pc, &rH};
-    EXPECT(secp256k1_ec_pubkey_combine(ctx, &PC_m, pts, 2));
-  }
-
-  /* PC_b = v*G + r_b*H  (paper convention: value on G, blinding on H) */
-  secp256k1_pubkey PC_b;
-  {
-    secp256k1_pubkey vG, rbH;
-    unsigned char v_scalar[32] = {0};
-    for (int b = 0; b < 8; b++)
-      v_scalar[31 - b] = (remainder >> (b * 8)) & 0xFF;
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &vG, v_scalar));
-    rbH = H;
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rbH, r_b));
-    const secp256k1_pubkey *pts[2] = {&vG, &rbH};
-    EXPECT(secp256k1_ec_pubkey_combine(ctx, &PC_b, pts, 2));
-  }
-
-  /* Balance ciphertext: C_bal = (r_bal*G, r_bal*pk_A + balance*G)
-   * Remainder: C_rem = C_bal - C_send_to_A
-   *   B1 = (r_bal - r)*G
-   *   B2 = (r_bal - r)*pk_A + (balance - amount)*G
-   *          = (r_bal - r)*pk_A + v*G
-   *
-   * Variant B relation: sk_A * B1 + v*G = B2
-   */
-  secp256k1_pubkey B1, B2;
-  {
-    /* B1 = (r_bal - r)*G */
-    unsigned char r_diff[32];
-    memcpy(r_diff, r_bal, 32);
-    unsigned char neg_r[32];
-    secp256k1_mpt_scalar_negate(neg_r, r);
-    secp256k1_mpt_scalar_add(r_diff, r_bal, neg_r);
-    /* Need to reduce */
-    secp256k1_mpt_scalar_reduce32(r_diff, r_diff);
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &B1, r_diff));
-
-    /* B2 = r_diff*pk_A + v*G */
-    secp256k1_pubkey rdPk, vG;
-    rdPk = pk_A;
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rdPk, r_diff));
-
-    unsigned char v_scalar[32] = {0};
-    for (int b = 0; b < 8; b++)
-      v_scalar[31 - b] = (remainder >> (b * 8)) & 0xFF;
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &vG, v_scalar));
-
-    const secp256k1_pubkey *pts[2] = {&rdPk, &vG};
-    EXPECT(secp256k1_ec_pubkey_combine(ctx, &B2, pts, 2));
-  }
-
-  /* Verify the Variant B relation holds: sk_A*B1 + v*G == B2 */
-  {
-    secp256k1_pubkey skC1r, vG, check;
-    skC1r = B1;
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &skC1r, sk_A));
-    unsigned char v_scalar[32] = {0};
-    for (int b = 0; b < 8; b++)
-      v_scalar[31 - b] = (remainder >> (b * 8)) & 0xFF;
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &vG, v_scalar));
-    const secp256k1_pubkey *pts[2] = {&skC1r, &vG};
-    EXPECT(secp256k1_ec_pubkey_combine(ctx, &check, pts, 2));
-    EXPECT(secp256k1_ec_pubkey_cmp(ctx, &check, &B2) == 0);
-    printf("Variant B relation verified.\n");
-  }
-
-  /* --- Positive Case --- */
-  printf("Generating compact standard proof for %d recipients...\n", N);
-
-  unsigned char proof[SECP256K1_COMPACT_STANDARD_PROOF_SIZE];
-  int res = secp256k1_compact_standard_prove(
-      ctx, proof, amount, remainder, r, sk_A, r_b, N, &C1, C2_vec, pks, &PC_m,
-      &pk_A, &PC_b, &B1, &B2, context_id);
-  EXPECT(res == 1);
-  printf("Proof generated: %d bytes.\n", SECP256K1_COMPACT_STANDARD_PROOF_SIZE);
-
-  res =
-      secp256k1_compact_standard_verify(ctx, proof, N, &C1, C2_vec, pks, &PC_m,
-                                        &pk_A, &PC_b, &B1, &B2, context_id);
-  EXPECT(res == 1);
-  printf("Proof verified successfully.\n");
-
-  /* --- Negative: Wrong context --- */
-  printf("Testing wrong context...\n");
-  {
-    unsigned char fake_ctx[32];
-    memcpy(fake_ctx, context_id, 32);
-    fake_ctx[0] ^= 0xFF;
-    res = secp256k1_compact_standard_verify(ctx, proof, N, &C1, C2_vec, pks,
-                                            &PC_m, &pk_A, &PC_b, &B1, &B2,
-                                            fake_ctx);
-    EXPECT(res == 0);
-  }
-  printf("Wrong context: rejected OK.\n");
-
-  /* --- Negative: Tampered C1 --- */
-  printf("Testing tampered C1...\n");
-  {
-    secp256k1_pubkey C1_bad = C1;
-    unsigned char tweak[32] = {0};
-    tweak[31] = 1;
-    EXPECT(secp256k1_ec_pubkey_tweak_add(ctx, &C1_bad, tweak));
-    res = secp256k1_compact_standard_verify(ctx, proof, N, &C1_bad, C2_vec, pks,
-                                            &PC_m, &pk_A, &PC_b, &B1, &B2,
-                                            context_id);
-    EXPECT(res == 0);
-  }
-  printf("Tampered C1: rejected OK.\n");
-
-  /* --- Negative: Tampered C2_0 --- */
-  printf("Testing tampered C2_0...\n");
-  {
-    secp256k1_pubkey C2_bad[3];
-    memcpy(C2_bad, C2_vec, sizeof(C2_vec));
-    unsigned char tweak[32] = {0};
-    tweak[31] = 1;
-    EXPECT(secp256k1_ec_pubkey_tweak_add(ctx, &C2_bad[0], tweak));
-    res = secp256k1_compact_standard_verify(ctx, proof, N, &C1, C2_bad, pks,
-                                            &PC_m, &pk_A, &PC_b, &B1, &B2,
-                                            context_id);
-    EXPECT(res == 0);
-  }
-  printf("Tampered C2_0: rejected OK.\n");
-
-  /* --- Negative: Corrupted proof byte --- */
-  printf("Testing corrupted proof...\n");
-  {
-    unsigned char bad[SECP256K1_COMPACT_STANDARD_PROOF_SIZE];
-    memcpy(bad, proof, SECP256K1_COMPACT_STANDARD_PROOF_SIZE);
-    bad[SECP256K1_COMPACT_STANDARD_PROOF_SIZE - 1] ^= 0x01;
-    res =
-        secp256k1_compact_standard_verify(ctx, bad, N, &C1, C2_vec, pks, &PC_m,
-                                          &pk_A, &PC_b, &B1, &B2, context_id);
-    EXPECT(res == 0);
-  }
-  printf("Corrupted proof: rejected OK.\n");
-
-  /* --- Negative: Wrong PC_b (wrong remainder) --- */
-  printf("Testing wrong PC_b...\n");
-  {
-    secp256k1_pubkey PC_b_bad;
-    unsigned char bad_rb[32];
-    random_scalar(ctx, bad_rb);
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &PC_b_bad, bad_rb));
-    res = secp256k1_compact_standard_verify(ctx, proof, N, &C1, C2_vec, pks,
-                                            &PC_m, &pk_A, &PC_b_bad, &B1, &B2,
-                                            context_id);
-    EXPECT(res == 0);
-  }
-  printf("Wrong PC_b: rejected OK.\n");
+  /* Zero-remainder case (v = 0, i.e. amount == balance): exercises the
+   * zero-witness path in compute_sigma_response for z_b, and the omitted-G
+   * -term path for PC_b / B2. */
+  run_compact_standard_case(ctx, /*amount=*/1000000, /*balance=*/1000000,
+                            /*run_negative_tests=*/0, "zero remainder");
 
   secp256k1_context_destroy(ctx);
-  printf("ALL COMPACT STANDARD SIGMA TESTS PASSED\n");
+  printf("\nALL COMPACT STANDARD SIGMA TESTS PASSED\n");
   return 0;
 }

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -5,8 +5,10 @@
 #include <openssl/sha.h>
 
 #include <secp256k1.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 /* --- Macro: Persistent Assertion --- */
 /* Ensures checks run in both Debug and Release modes */
@@ -35,5 +37,29 @@ random_scalar(secp256k1_context const* ctx, unsigned char* out)
     {
         EXPECT(RAND_bytes(out, 32) == 1);
     } while (!secp256k1_ec_seckey_verify(ctx, out));
+}
+
+/* Helper: Encode uint64 as 32-byte big-endian scalar. */
+static inline void
+uint64_to_scalar32(unsigned char out[32], uint64_t v)
+{
+    memset(out, 0, 32);
+    for (int i = 0; i < 8; i++)
+        out[31 - i] = (v >> (i * 8)) & 0xFF;
+}
+
+/* Helper: Compute v*G. Returns 1 and writes *out on success; returns 0
+ * when v == 0 (libsecp256k1's public API cannot emit the point at
+ * infinity, so callers must skip the v*G term themselves). */
+static inline int
+value_times_g(secp256k1_context const* ctx, secp256k1_pubkey* out, uint64_t v)
+{
+    if (v == 0)
+        return 0;
+    unsigned char s[32];
+    uint64_to_scalar32(s, v);
+    int ok = secp256k1_ec_pubkey_create(ctx, out, s);
+    memset(s, 0, sizeof(s));
+    return ok;
 }
 #endif  // MPT_TEST_UTILS_H


### PR DESCRIPTION
## Summary

Fixes the zero-witness issue in `compute_sigma_response` (tracks #38) and tightens negative-path assertions in the aggregated bulletproof tests.

## The bug (issue #38)

`compute_sigma_response` previously used `secp256k1_ec_seckey_tweak_mul` / `secp256k1_ec_seckey_tweak_add` to compute `z = nonce + e * secret (mod n)`. Those APIs call `seckey_verify` internally and reject scalars that are zero or ≥ group order — so whenever the witness (e.g. amount `m = 0` or balance remainder `v = 0`) is zero, the intermediate `e * secret` term is zero and the call fails. The prover then aborts on a legal zero-valued statement.

## Fix

Switch to the internal scalar-field helpers `secp256k1_mpt_scalar_mul` / `secp256k1_mpt_scalar_add`, which operate on full 32-byte field elements and never reject zero. `compute_sigma_response` becomes infallible (`void`), so all 10 call sites across the four sigma-proof variants drop their error-handling branches:

- `proof_compact_standard.c` (5 sites: `z_r`, `z_m`, `z_sk`, `z_rb`, `z_b`)
- `proof_compact_convertback.c` (3 sites: `z_b`, `z_sk`, `z_rho`)
- `proof_compact_clawback.c` (1 site: `z_sk`)
- `proof_pok_sk.c` (1 site: `s`)

### New tests

- `tests/test_compact_standard.c` — factored into a parameterized case-runner; adds *zero amount* (`m = 0`) and *zero remainder* (`v = amount = balance`) cases on top of the primary non-zero case.
- `tests/test_compact_convertback.c` — factored similarly; adds *zero balance* case.
- Both rely on a small `value_times_g` / `uint64_to_scalar32` helper added to `tests/test_utils.h`, which skips the `v*G` term when `v = 0` (libsecp's public API cannot emit the point at infinity).

Full `ctest`: 13/13 pass with `-Werror`.

## Second commit: ToB April 2026 fix-review p-66 caveat (RIPCTX-6)

The ToB fix-review flagged that the aggregated-bulletproof negative tests were only checking *absence of crash*, not *rejection*. This commit:

1. Replaces the prior `if (ok) { fprintf; exit; }` pattern with `EXPECT(ok == 0)` for the tampered-value case.
2. Adds a second negative test (*same value, different blinding*) that exercises the rejection path even when the value witness itself is 0 (no G-term in the original commitment).

## Follow-up (not in this PR)

Zero-amount handling in the Fiat-Shamir transcripts + clawback path (#39) is a separate concern — tracked for a follow-up PR.

## Test plan

- [x] `ctest` passes 13/13 with `-Werror`
- [x] Zero-amount, zero-remainder, zero-balance cases exercise the new code path specifically
- [x] Pre-commit hooks pass (clang-format, gersemi, etc.)
