### PR TITLE
fix: handle zero amount in clawback Fiat-Shamir transcript

### DIFF
--- a/src/proof_compact_clawback.c
+++ b/src/proof_compact_clawback.c
@@ -31,12 +31,39 @@
 
 static const char DOMAIN_COMPACT_CLAWBACK[] = "CMPT_CLAWBACK_SIGMA";
 
+/* Feed m*G into an SHA-256 stream as 33 compressed bytes. When amount == 0,
+ * libsecp256k1 cannot represent (and therefore cannot serialize) the point
+ * at infinity, so we substitute 33 zero bytes. 33 zeros is not a valid
+ * compressed-point encoding (the valid prefixes are 0x02 and 0x03), so the
+ * sentinel is unambiguous and cannot collide with a real m*G. Prover and
+ * verifier must both use this helper so the transcript stays consistent. */
+static int digest_update_amount_point(const secp256k1_context *ctx,
+                                      EVP_MD_CTX *mdctx, uint64_t amount)
+{
+  unsigned char buf[33];
+  if (amount == 0)
+  {
+    memset(buf, 0, 33);
+  }
+  else
+  {
+    secp256k1_pubkey mG;
+    size_t len = 33;
+    if (!compute_amount_point(ctx, &mG, amount))
+      return 0;
+    if (!secp256k1_ec_pubkey_serialize(ctx, buf, &len, &mG,
+                                       SECP256K1_EC_COMPRESSED) ||
+        len != 33)
+      return 0;
+  }
+  return EVP_DigestUpdate(mdctx, buf, 33);
+}
+
 static int compute_compact_clawback_challenge(
     const secp256k1_context *ctx, unsigned char *e_out,
     const secp256k1_pubkey *P_iss, const secp256k1_pubkey *C1,
-    const secp256k1_pubkey *C2, const secp256k1_pubkey *mG,
-    const secp256k1_pubkey *T1, const secp256k1_pubkey *T2,
-    const unsigned char *context_id)
+    const secp256k1_pubkey *C2, uint64_t amount, const secp256k1_pubkey *T1,
+    const secp256k1_pubkey *T2, const unsigned char *context_id)
 {
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
   unsigned char buf[33];
@@ -65,11 +92,12 @@ static int compute_compact_clawback_challenge(
       goto cleanup;                                                            \
   } while (0)
 
-  /* Statement: P_iss || C1 || C2 || m*G */
+  /* Statement: P_iss || C1 || C2 || m*G (33 zero bytes when amount=0) */
   SER(P_iss);
   SER(C1);
   SER(C2);
-  SER(mG);
+  if (!digest_update_amount_point(ctx, mdctx, amount))
+    goto cleanup;
 
   /* Commitments: T1 || T2 */
   SER(T1);
@@ -112,15 +140,11 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
 
   unsigned char t_sk[32];
   unsigned char e[32], z_sk[32];
-  secp256k1_pubkey mG, T1, T2;
+  secp256k1_pubkey T1, T2;
   int ok = 0;
 
   if (!secp256k1_ec_seckey_verify(ctx, sk_iss))
     return 0;
-
-  /* Compute m*G as a group element */
-  if (!compute_amount_point(ctx, &mG, amount))
-    goto cleanup;
 
   /* 1. Deterministic nonce */
   {
@@ -165,7 +189,12 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
       SHASH(P_iss);
       SHASH(C1);
       SHASH(C2);
-      SHASH(&mG);
+      if (!digest_update_amount_point(ctx, sh, amount))
+      {
+        EVP_MD_CTX_free(sh);
+        OPENSSL_cleanse(witness_buf, sizeof(witness_buf));
+        goto cleanup;
+      }
       if (context_id)
       {
         if (EVP_DigestUpdate(sh, context_id, 32) != 1)
@@ -202,8 +231,8 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
     goto cleanup;
 
   /* 3. Challenge */
-  if (!compute_compact_clawback_challenge(ctx, e, P_iss, C1, C2, &mG, &T1, &T2,
-                                          context_id))
+  if (!compute_compact_clawback_challenge(ctx, e, P_iss, C1, C2, amount, &T1,
+                                          &T2, context_id))
     goto cleanup;
 
   /* 4. Response: z_sk = t_sk + e*sk_iss */
@@ -237,7 +266,7 @@ int secp256k1_compact_clawback_verify(
   MPT_ARG_CHECK(C2 != NULL);
 
   unsigned char e[32], z_sk[32], e_prime[32], neg_e[32];
-  secp256k1_pubkey mG, T1, T2;
+  secp256k1_pubkey T1, T2;
 
   /* 1. Deserialize: e || z_sk */
   memcpy(e, proof, 32);
@@ -246,10 +275,6 @@ int secp256k1_compact_clawback_verify(
   if (!secp256k1_ec_seckey_verify(ctx, e))
     return 0;
   if (!secp256k1_ec_seckey_verify(ctx, z_sk))
-    return 0;
-
-  /* Compute m*G as a group element */
-  if (!compute_amount_point(ctx, &mG, amount))
     return 0;
 
   secp256k1_mpt_scalar_negate(neg_e, e);
@@ -269,21 +294,31 @@ int secp256k1_compact_clawback_verify(
       return 0;
   }
 
-  /* T2 = z_sk*C1 - e*(C2 - m*G) */
+  /* T2 = z_sk*C1 - e*(C2 - m*G); when amount=0 the -m*G term is the point
+   * at infinity, so C2 - m*G collapses to C2 and we skip the subtraction. */
   {
     secp256k1_pubkey zskC1, eTarget;
-    /* Compute C2 - m*G */
-    unsigned char neg_one[32];
-    unsigned char one[32] = {0};
-    one[31] = 1;
-    secp256k1_mpt_scalar_negate(neg_one, one);
-    secp256k1_pubkey neg_mG = mG;
-    if (!secp256k1_ec_pubkey_tweak_mul(ctx, &neg_mG, neg_one))
-      return 0;
     secp256k1_pubkey C2_minus_mG;
-    const secp256k1_pubkey *sub_pts[2] = {C2, &neg_mG};
-    if (!secp256k1_ec_pubkey_combine(ctx, &C2_minus_mG, sub_pts, 2))
-      return 0;
+    if (amount == 0)
+    {
+      C2_minus_mG = *C2;
+    }
+    else
+    {
+      secp256k1_pubkey mG;
+      if (!compute_amount_point(ctx, &mG, amount))
+        return 0;
+      unsigned char neg_one[32];
+      unsigned char one[32] = {0};
+      one[31] = 1;
+      secp256k1_mpt_scalar_negate(neg_one, one);
+      secp256k1_pubkey neg_mG = mG;
+      if (!secp256k1_ec_pubkey_tweak_mul(ctx, &neg_mG, neg_one))
+        return 0;
+      const secp256k1_pubkey *sub_pts[2] = {C2, &neg_mG};
+      if (!secp256k1_ec_pubkey_combine(ctx, &C2_minus_mG, sub_pts, 2))
+        return 0;
+    }
 
     zskC1 = *C1;
     if (!secp256k1_ec_pubkey_tweak_mul(ctx, &zskC1, z_sk))
@@ -297,8 +332,8 @@ int secp256k1_compact_clawback_verify(
   }
 
   /* 3. Recompute challenge */
-  if (!compute_compact_clawback_challenge(ctx, e_prime, P_iss, C1, C2, &mG, &T1,
-                                          &T2, context_id))
+  if (!compute_compact_clawback_challenge(ctx, e_prime, P_iss, C1, C2, amount,
+                                          &T1, &T2, context_id))
     return 0;
 
   /* 4. Accept iff e' == e */

--- a/tests/test_compact_clawback.c
+++ b/tests/test_compact_clawback.c
@@ -4,6 +4,153 @@
 #include <stdio.h>
 #include <string.h>
 
+/* Encode uint64 as a 32-byte big-endian scalar (local to this test; the
+ * helper from PR A's test_utils.h is not yet on this branch). */
+static void clawback_uint64_to_scalar32(unsigned char out[32], uint64_t v)
+{
+  memset(out, 0, 32);
+  for (int i = 0; i < 8; i++)
+    out[31 - i] = (v >> (i * 8)) & 0xFF;
+}
+
+/* Build C1 = r*G, C2 = m*G + r*P_iss (m*G term skipped when m == 0 —
+ * libsecp256k1 cannot emit the point at infinity). Runs the full
+ * prove/verify flow plus optional negative-path assertions.
+ */
+static void run_clawback_case(const secp256k1_context *ctx, uint64_t amount,
+                              int run_negative_tests, const char *label)
+{
+  printf("\n--- %s (amount=%llu) ---\n", label, (unsigned long long)amount);
+
+  unsigned char sk_iss[32], r_enc[32], context_id[32];
+  secp256k1_pubkey P_iss;
+
+  random_scalar(ctx, sk_iss);
+  random_scalar(ctx, r_enc);
+  random_bytes(context_id);
+
+  EXPECT(secp256k1_ec_pubkey_create(ctx, &P_iss, sk_iss));
+
+  /* C1 = r*G */
+  secp256k1_pubkey C1;
+  EXPECT(secp256k1_ec_pubkey_create(ctx, &C1, r_enc));
+
+  /* C2 = r*P_iss (+ m*G if amount > 0) */
+  secp256k1_pubkey C2;
+  {
+    secp256k1_pubkey rP = P_iss;
+    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rP, r_enc));
+    if (amount > 0)
+    {
+      unsigned char m_scalar[32];
+      clawback_uint64_to_scalar32(m_scalar, amount);
+      secp256k1_pubkey mG;
+      EXPECT(secp256k1_ec_pubkey_create(ctx, &mG, m_scalar));
+      const secp256k1_pubkey *pts[2] = {&mG, &rP};
+      EXPECT(secp256k1_ec_pubkey_combine(ctx, &C2, pts, 2));
+    }
+    else
+    {
+      C2 = rP;
+    }
+  }
+
+  /* Sanity: C2 - m*G == sk_iss*C1 (i.e., r*P_iss == sk_iss*r*G). When
+   * amount=0, m*G is infinity so C2 - m*G == C2 and we skip the
+   * subtraction. */
+  {
+    secp256k1_pubkey lhs;
+    if (amount == 0)
+    {
+      lhs = C2;
+    }
+    else
+    {
+      unsigned char m_scalar[32];
+      clawback_uint64_to_scalar32(m_scalar, amount);
+      secp256k1_pubkey mG;
+      EXPECT(secp256k1_ec_pubkey_create(ctx, &mG, m_scalar));
+      unsigned char neg_one[32];
+      unsigned char one[32] = {0};
+      one[31] = 1;
+      secp256k1_mpt_scalar_negate(neg_one, one);
+      secp256k1_pubkey neg_mG = mG;
+      EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &neg_mG, neg_one));
+      const secp256k1_pubkey *sub_pts[2] = {&C2, &neg_mG};
+      EXPECT(secp256k1_ec_pubkey_combine(ctx, &lhs, sub_pts, 2));
+    }
+    secp256k1_pubkey skC1 = C1;
+    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &skC1, sk_iss));
+    EXPECT(secp256k1_ec_pubkey_cmp(ctx, &lhs, &skC1) == 0);
+    printf("  relation OK: C2 - m*G == sk_iss*C1.\n");
+  }
+
+  /* Positive case */
+  unsigned char proof[SECP256K1_COMPACT_CLAWBACK_PROOF_SIZE];
+  int res = secp256k1_compact_clawback_prove(ctx, proof, amount, sk_iss, &P_iss,
+                                             &C1, &C2, context_id);
+  EXPECT(res == 1);
+
+  res = secp256k1_compact_clawback_verify(ctx, proof, amount, &P_iss, &C1, &C2,
+                                          context_id);
+  EXPECT(res == 1);
+  printf("  prove + verify OK.\n");
+
+  if (!run_negative_tests)
+    return;
+
+  /* Negative: Wrong context */
+  {
+    unsigned char fake_ctx[32];
+    memcpy(fake_ctx, context_id, 32);
+    fake_ctx[0] ^= 0xFF;
+    res = secp256k1_compact_clawback_verify(ctx, proof, amount, &P_iss, &C1,
+                                            &C2, fake_ctx);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Corrupted proof byte */
+  {
+    unsigned char bad[SECP256K1_COMPACT_CLAWBACK_PROOF_SIZE];
+    memcpy(bad, proof, SECP256K1_COMPACT_CLAWBACK_PROOF_SIZE);
+    bad[SECP256K1_COMPACT_CLAWBACK_PROOF_SIZE - 1] ^= 0x01;
+    res = secp256k1_compact_clawback_verify(ctx, bad, amount, &P_iss, &C1, &C2,
+                                            context_id);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Wrong amount */
+  {
+    res = secp256k1_compact_clawback_verify(ctx, proof, amount + 1, &P_iss, &C1,
+                                            &C2, context_id);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Wrong C1 */
+  {
+    secp256k1_pubkey C1_bad = C1;
+    unsigned char tweak[32] = {0};
+    tweak[31] = 1;
+    EXPECT(secp256k1_ec_pubkey_tweak_add(ctx, &C1_bad, tweak));
+    res = secp256k1_compact_clawback_verify(ctx, proof, amount, &P_iss, &C1_bad,
+                                            &C2, context_id);
+    EXPECT(res == 0);
+  }
+
+  /* Negative: Wrong issuer key */
+  {
+    unsigned char sk_bad[32];
+    secp256k1_pubkey pk_bad;
+    random_scalar(ctx, sk_bad);
+    EXPECT(secp256k1_ec_pubkey_create(ctx, &pk_bad, sk_bad));
+    res = secp256k1_compact_clawback_verify(ctx, proof, amount, &pk_bad, &C1,
+                                            &C2, context_id);
+    EXPECT(res == 0);
+  }
+
+  printf("  negative-path checks OK.\n");
+}
+
 int main(void)
 {
   secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN |
@@ -16,128 +163,18 @@ int main(void)
 
   printf("=== Running Test: Compact Clawback Proof (64 bytes) ===\n");
 
-  uint64_t amount = 500000;
+  /* Primary case: non-zero amount. Runs full negatives. */
+  run_clawback_case(ctx, /*amount=*/500000, /*run_negative_tests=*/1,
+                    "primary");
 
-  unsigned char sk_iss[32], r_enc[32], context_id[32];
-  secp256k1_pubkey P_iss;
-
-  random_scalar(ctx, sk_iss);
-  random_scalar(ctx, r_enc);
-  random_scalar(ctx, context_id);
-
-  EXPECT(secp256k1_ec_pubkey_create(ctx, &P_iss, sk_iss));
-
-  /* Issuer-mirror ciphertext: C1 = r*G, C2 = m*G + r*P_iss */
-  secp256k1_pubkey C1, C2;
-  EXPECT(secp256k1_ec_pubkey_create(ctx, &C1, r_enc));
-  {
-    unsigned char m_scalar[32] = {0};
-    for (int b = 0; b < 8; b++)
-      m_scalar[31 - b] = (amount >> (b * 8)) & 0xFF;
-    secp256k1_pubkey mG, rP;
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &mG, m_scalar));
-    rP = P_iss;
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &rP, r_enc));
-    const secp256k1_pubkey *pts[2] = {&mG, &rP};
-    EXPECT(secp256k1_ec_pubkey_combine(ctx, &C2, pts, 2));
-  }
-
-  /* Verify relation: C2 - m*G = sk_iss*C1 (i.e., r*P_iss = sk_iss*r*G) */
-  {
-    unsigned char m_scalar[32] = {0};
-    for (int b = 0; b < 8; b++)
-      m_scalar[31 - b] = (amount >> (b * 8)) & 0xFF;
-    secp256k1_pubkey mG;
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &mG, m_scalar));
-    unsigned char neg_one[32];
-    unsigned char one[32] = {0};
-    one[31] = 1;
-    secp256k1_mpt_scalar_negate(neg_one, one);
-    secp256k1_pubkey neg_mG = mG;
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &neg_mG, neg_one));
-    secp256k1_pubkey lhs;
-    const secp256k1_pubkey *sub_pts[2] = {&C2, &neg_mG};
-    EXPECT(secp256k1_ec_pubkey_combine(ctx, &lhs, sub_pts, 2));
-    secp256k1_pubkey skC1 = C1;
-    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &skC1, sk_iss));
-    EXPECT(secp256k1_ec_pubkey_cmp(ctx, &lhs, &skC1) == 0);
-    printf("Clawback relation verified: C2 - m*G == sk_iss*C1.\n");
-  }
-
-  /* --- Positive Case --- */
-  printf("Generating compact clawback proof...\n");
-
-  unsigned char proof[SECP256K1_COMPACT_CLAWBACK_PROOF_SIZE];
-  int res = secp256k1_compact_clawback_prove(ctx, proof, amount, sk_iss, &P_iss,
-                                             &C1, &C2, context_id);
-  EXPECT(res == 1);
-  printf("Proof generated: %d bytes.\n", SECP256K1_COMPACT_CLAWBACK_PROOF_SIZE);
-
-  res = secp256k1_compact_clawback_verify(ctx, proof, amount, &P_iss, &C1, &C2,
-                                          context_id);
-  EXPECT(res == 1);
-  printf("Proof verified successfully.\n");
-
-  /* --- Negative: Wrong context --- */
-  printf("Testing wrong context...\n");
-  {
-    unsigned char fake_ctx[32];
-    memcpy(fake_ctx, context_id, 32);
-    fake_ctx[0] ^= 0xFF;
-    res = secp256k1_compact_clawback_verify(ctx, proof, amount, &P_iss, &C1,
-                                            &C2, fake_ctx);
-    EXPECT(res == 0);
-  }
-  printf("Wrong context: rejected OK.\n");
-
-  /* --- Negative: Corrupted proof byte --- */
-  printf("Testing corrupted proof...\n");
-  {
-    unsigned char bad[SECP256K1_COMPACT_CLAWBACK_PROOF_SIZE];
-    memcpy(bad, proof, SECP256K1_COMPACT_CLAWBACK_PROOF_SIZE);
-    bad[SECP256K1_COMPACT_CLAWBACK_PROOF_SIZE - 1] ^= 0x01;
-    res = secp256k1_compact_clawback_verify(ctx, bad, amount, &P_iss, &C1, &C2,
-                                            context_id);
-    EXPECT(res == 0);
-  }
-  printf("Corrupted proof: rejected OK.\n");
-
-  /* --- Negative: Wrong amount --- */
-  printf("Testing wrong amount...\n");
-  {
-    res = secp256k1_compact_clawback_verify(ctx, proof, amount + 1, &P_iss, &C1,
-                                            &C2, context_id);
-    EXPECT(res == 0);
-  }
-  printf("Wrong amount: rejected OK.\n");
-
-  /* --- Negative: Wrong C1 (tampered ciphertext) --- */
-  printf("Testing tampered C1...\n");
-  {
-    secp256k1_pubkey C1_bad = C1;
-    unsigned char tweak[32] = {0};
-    tweak[31] = 1;
-    EXPECT(secp256k1_ec_pubkey_tweak_add(ctx, &C1_bad, tweak));
-    res = secp256k1_compact_clawback_verify(ctx, proof, amount, &P_iss, &C1_bad,
-                                            &C2, context_id);
-    EXPECT(res == 0);
-  }
-  printf("Tampered C1: rejected OK.\n");
-
-  /* --- Negative: Wrong issuer key --- */
-  printf("Testing wrong issuer key...\n");
-  {
-    unsigned char sk_bad[32];
-    secp256k1_pubkey pk_bad;
-    random_scalar(ctx, sk_bad);
-    EXPECT(secp256k1_ec_pubkey_create(ctx, &pk_bad, sk_bad));
-    res = secp256k1_compact_clawback_verify(ctx, proof, amount, &pk_bad, &C1,
-                                            &C2, context_id);
-    EXPECT(res == 0);
-  }
-  printf("Wrong issuer key: rejected OK.\n");
+  /* Zero-amount case: exercises the 33-zero-bytes transcript convention and
+   * the omitted-m*G paths in prove/verify. Tracks issue #39 and ToB S9/I9.
+   * Negatives are enabled: the "wrong amount" negative becomes amount=1,
+   * which specifically exercises the transcript-distinguishability boundary
+   * between the 33-zero sentinel and a serialized 1*G. */
+  run_clawback_case(ctx, /*amount=*/0, /*run_negative_tests=*/1, "zero amount");
 
   secp256k1_context_destroy(ctx);
-  printf("ALL COMPACT CLAWBACK TESTS PASSED\n");
+  printf("\nALL COMPACT CLAWBACK TESTS PASSED\n");
   return 0;
 }


### PR DESCRIPTION
## Summary

Fixes the zero-amount abort in the compact clawback proof. Tracks issue #39. Also responds to the broader zero-handling theme in the ToB code-quality findings (Appendix B, "Code Quality Issues" — discrepancy between implementation and specification for zero-handling).

This PR is independent of the companion PR #58 (sigma-response zero witness) — they touch disjoint code and can merge in either order.

## The bug (issue #39 / internal S9/I9)

In `proof_compact_clawback.c`, both the prover and the verifier unconditionally call `compute_amount_point(ctx, &mG, amount)` to obtain the statement point `m*G`. That helper returns 0 when `amount == 0` (libsecp256k1 cannot represent the point at infinity), so the prove/verify flow aborts on legitimate zero-balance clawback ciphertexts.

The Fiat-Shamir transcript additionally serializes `m*G` as 33 compressed bytes. When `amount = 0`, there is no point to serialize — the internal S9/I9 note recommends substituting 33 zero bytes in this position so the transcript remains well-defined.

## Fix

**Unified transcript helper** — new static function `digest_update_amount_point()` encapsulates the convention in exactly one place:

- `amount > 0`: feed the 33-byte compressed encoding of `m*G`.
- `amount == 0`: feed 33 zero bytes.

33 zeros is not a valid compressed-point encoding (valid prefixes are `0x02` / `0x03`), so the sentinel is unambiguous and cannot collide with any real `m*G`.

`compute_compact_clawback_challenge()` now takes `uint64_t amount` instead of `const secp256k1_pubkey *mG`. Both prover and verifier pass `amount` directly, so the transcript convention can never drift between the two sides.

**Prover**
- Drops the unconditional `compute_amount_point()` call (and the `mG` local) at the top of the function.
- The inline `stmt_hash` used for deterministic-nonce generation now calls the same `digest_update_amount_point()` helper, so prover-side nonce derivation is also well-defined at `amount = 0`.

**Verifier**
- Drops the unconditional `compute_amount_point()` call.
- Reconstructs `T2 = z_sk*C1 - e*(C2 - m*G)` by short-circuiting `C2 - m*G` to `C2` when `amount == 0` (the `-m*G` term is the point at infinity).

## Why not change `equality_proof.c` too?

`equality_proof.c` currently handles `amount = 0` by **omitting** the `m*G` term from the hash (variable-length transcript). Internal S9/I9 recommends the same 33-zero-bytes convention there. That file is slated for removal in #25, so this PR does not change it — touching a soon-to-be-deleted transcript would create pointless merge noise. If #25 stalls, a follow-up can align `equality_proof.c` with the convention chosen here.

## For team discussion

I picked **33 zero bytes** as the sentinel for "no `m*G`" in the transcript. Alternatives considered:

| Option | Transcript bytes for m=0 | Notes |
|---|---|---|
| **33 zero bytes (chosen)** | fixed | Matches internal S9/I9 recommendation. Fixed-length, unambiguous (not a valid compressed encoding). |
| Omit the term | variable | What `equality_proof.c` does today. Variable-length hash inputs are a mild footgun. |
| 1-byte domain-separator sentinel | fixed (1) | Non-standard; no precedent in this codebase. |

Happy to revisit if anyone prefers a different convention — this PR is the first time it's been applied in mpt-crypto and sets precedent.

## Test plan

- [x] \`tests/test_compact_clawback.c\` refactored into a parameterized case-runner.
- [x] **Primary case** (amount = 500000): full negative-path battery passes.
- [x] **Zero-amount case** (amount = 0): prove + verify succeed; full negatives pass. The "wrong amount" negative becomes \`amount + 1 = 1\`, which specifically exercises the transcript-distinguishability boundary between the 33-zero sentinel and a serialized \`1*G\`.
- [x] Full \`ctest\`: 13/13 pass.
- [x] Pre-commit hooks pass (clang-format, etc.).