### PR TITLE
fix: handle t1=0 and t2=0 in bulletproof aggregated prover

### DIFF
--- a/src/bulletproof_aggregated.c
+++ b/src/bulletproof_aggregated.c
@@ -1574,46 +1574,54 @@ int secp256k1_bulletproof_prove_agg(const secp256k1_context *ctx,
     goto cleanup;
 
   /* ---- 8. Commit T1, T2 ---- */
-  /* T1 = t1*G + tau1*Base   where G = G_vec[0] */
+  /* T1 = t1*G + tau1*Base   where G = G_vec[0].
+   * When t1 == 0 the t1*G term is the point at infinity (which libsecp256k1
+   * cannot emit), so commit T1 = tau1*Base directly. */
   {
     secp256k1_pubkey tG, tB;
     const secp256k1_pubkey *pts[2];
-
-    if (memcmp(t1, zero, 32) == 0)
-      goto cleanup; /* prototype guard */
-    /* tG = t1 * (curve base generator) */
-    if (!secp256k1_ec_pubkey_create(ctx, &tG, t1))
-      goto cleanup;
 
     tB = *pk_base;
     if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tB, tau1))
       goto cleanup;
 
-    pts[0] = &tG;
-    pts[1] = &tB;
-    if (!secp256k1_ec_pubkey_combine(ctx, &T1, pts, 2))
-      goto cleanup;
+    if (memcmp(t1, zero, 32) == 0)
+    {
+      T1 = tB;
+    }
+    else
+    {
+      if (!secp256k1_ec_pubkey_create(ctx, &tG, t1))
+        goto cleanup;
+      pts[0] = &tG;
+      pts[1] = &tB;
+      if (!secp256k1_ec_pubkey_combine(ctx, &T1, pts, 2))
+        goto cleanup;
+    }
   }
 
-  /* T2 = t2*G + tau2*Base */
+  /* T2 = t2*G + tau2*Base. Same t2==0 short-circuit as above. */
   {
     secp256k1_pubkey tG, tB;
     const secp256k1_pubkey *pts[2];
-
-    if (memcmp(t2, zero, 32) == 0)
-      goto cleanup; /* prototype guard */
-    /* tG = t2 * (curve base generator) */
-    if (!secp256k1_ec_pubkey_create(ctx, &tG, t2))
-      goto cleanup;
 
     tB = *pk_base;
     if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tB, tau2))
       goto cleanup;
 
-    pts[0] = &tG;
-    pts[1] = &tB;
-    if (!secp256k1_ec_pubkey_combine(ctx, &T2, pts, 2))
-      goto cleanup;
+    if (memcmp(t2, zero, 32) == 0)
+    {
+      T2 = tB;
+    }
+    else
+    {
+      if (!secp256k1_ec_pubkey_create(ctx, &tG, t2))
+        goto cleanup;
+      pts[0] = &tG;
+      pts[1] = &tB;
+      if (!secp256k1_ec_pubkey_combine(ctx, &T2, pts, 2))
+        goto cleanup;
+    }
   }
 
   /* ---- 9. Challenge x ---- */


### PR DESCRIPTION
## Summary

Closes #41.

Drops the two `memcmp(t, zero, 32) == 0 => goto cleanup` "prototype guards" in `secp256k1_bulletproof_prove_agg` and replaces them with the same short-circuit pattern used by #59 for the clawback `m=0` case: when the polynomial coefficient is zero, commit `T = tau*Base` directly (the `t*G` term is the point at infinity, which libsecp256k1's public API cannot emit).

Independent of #58 / #59 — touches `bulletproof_aggregated.c` only, no overlap with the sigma-protocol files those PRs changed. Continues the zero-value-cluster cleanup; companion follow-up for #51 (`generate_deterministic_nonces` zero-after-reduce) is planned as a separate PR.

## The bug

`bulletproof_aggregated.c:1582` and `:1603` previously read:

```c
if (memcmp(t1, zero, 32) == 0)
  goto cleanup; /* prototype guard */
...
if (memcmp(t2, zero, 32) == 0)
  goto cleanup; /* prototype guard */
```

`t1 = <l0, r1> + <l1, r0>` and `t2 = <l1, r1>` are inner-product polynomial coefficients derived from the witness vectors. Both can hit zero with negligible-but-nonzero probability (~1/2^256). When that happens the prover currently aborts on a structurally valid input.

The associated commitment math is well-defined at `t = 0`:
`T = 0*G + tau*Base = tau*Base`,
which is a valid Pedersen commitment. The verifier consumes `T1` and `T2` as opaque points (it never re-derives them from `t`), so no verifier-side change is needed.

## Fix

```c
tB = *pk_base;
if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tB, tau1))
  goto cleanup;

if (memcmp(t1, zero, 32) == 0)
{
  T1 = tB;                 /* t1*G is the identity, drop it */
}
else
{
  if (!secp256k1_ec_pubkey_create(ctx, &tG, t1))
    goto cleanup;
  ... combine tG + tB into T1 ...
}
```

Symmetric for `T2` / `tau2` / `t2`.

The explicit branch is unavoidable: libsecp256k1's public API rejects the zero scalar in `secp256k1_ec_pubkey_create` and cannot emit the point at infinity. Same structural reason `proof_compact_clawback.c` needed the equivalent special case for `amount = 0` in #59.

## What the auditors said

- **GH issue #41**: Sonnet 4.6 flagged the silent failure ("`T1 = tau1*Base` is still a valid commitment") at Medium severity; Augment Code at Low (negligible probability). Neither prescribed a concrete fix path.
- **ToB report (March + April 2026 fix-review)**: does **not** discuss the `t1`/`t2` guards specifically. The closest item, **RIPCTX-6** ("Aggregated Bulletproofs cannot handle certain in-range values"), is about the multi-scalar multiplication accumulator (all-zero / all-UINT64_MAX inputs) and recommends generic *"improve point-at-infinity handling in the mpt-crypto library"*. This PR is in line with that guidance but addresses a different sub-case.

So the fix is being chosen on first principles, with the structural pattern precedented by #59.

## Test plan

- [x] Full `ctest`: 13/13 pass (no regressions).
- [x] Pre-commit hooks pass (`clang-format`, etc.).
- [ ] **No direct unit test for `t = 0`.** The path is statistically unreachable in normal operation (~1/2^256 hit rate per call). Forcing entry would require either constructing a specific witness that produces `t = 0` (requires inverting the inner-product structure end-to-end, very difficult) or adding a debug-only injection hook (reluctant — adds production code purely for testing). Happy to add a property-based fuzz scaffold or an injection hook in a follow-up if reviewers want explicit coverage.

## Compatibility

No proof-format change, no API change, no transcript change. Existing proofs continue to verify; existing prover output is byte-identical for any `t1, t2 != 0` (which is every realistic prove call ever made).