### PR TITLE
fix: retry deterministic nonce derivation on zero-after-reduce

### DIFF
--- a/src/mpt_internal.h
+++ b/src/mpt_internal.h
@@ -184,7 +184,13 @@ generate_deterministic_nonces(
         EVP_MAC_free(mac);
     }
 
-    /* Expand: nonce_i = HMAC-SHA256(PRK, prev || counter) */
+    /* Expand: nonce_i = HMAC-SHA256(PRK, prev || counter [|| sub_counter])
+     *
+     * If the reduced output happens to be 0 mod n (negligible ~1/2^256), retry
+     * by appending an extra sub_counter byte to the MAC input and re-deriving.
+     * sub_counter == 0 skips the extra update so the no-retry path is byte-
+     * identical to the prior derivation. Cap retries at 256 (~1/2^65536) before
+     * giving up. */
     {
         unsigned char prev[32];
         memset(prev, 0, 32);
@@ -193,41 +199,59 @@ generate_deterministic_nonces(
         {
             unsigned char counter = (unsigned char)(i + 1);
             unsigned char out[32];
+            int sub_counter;
+            int accepted = 0;
 
-            EVP_MAC* mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
-            if (!mac)
+            for (sub_counter = 0; sub_counter < 256; sub_counter++)
             {
-                OPENSSL_cleanse(prk, 32);
-                OPENSSL_cleanse(nonces_out, k * 32);
-                return 0;
-            }
-            EVP_MAC_CTX* mctx = EVP_MAC_CTX_new(mac);
-            if (!mctx)
-            {
+                EVP_MAC* mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+                if (!mac)
+                {
+                    OPENSSL_cleanse(prk, 32);
+                    OPENSSL_cleanse(nonces_out, k * 32);
+                    return 0;
+                }
+                EVP_MAC_CTX* mctx = EVP_MAC_CTX_new(mac);
+                if (!mctx)
+                {
+                    EVP_MAC_free(mac);
+                    OPENSSL_cleanse(prk, 32);
+                    OPENSSL_cleanse(nonces_out, k * 32);
+                    return 0;
+                }
+                OSSL_PARAM params[] = {
+                    OSSL_PARAM_construct_utf8_string("digest", "SHA256", 0),
+                    OSSL_PARAM_construct_end()};
+                EVP_MAC_init(mctx, prk, 32, params);
+                if (i > 0)
+                    EVP_MAC_update(mctx, prev, 32);
+                EVP_MAC_update(mctx, &counter, 1);
+                if (sub_counter > 0)
+                {
+                    unsigned char sub = (unsigned char)sub_counter;
+                    EVP_MAC_update(mctx, &sub, 1);
+                }
+                size_t mac_len = 32;
+                EVP_MAC_final(mctx, out, &mac_len, 32);
+                EVP_MAC_CTX_free(mctx);
                 EVP_MAC_free(mac);
-                OPENSSL_cleanse(prk, 32);
-                OPENSSL_cleanse(nonces_out, k * 32);
-                return 0;
-            }
-            OSSL_PARAM params[] = {
-                OSSL_PARAM_construct_utf8_string("digest", "SHA256", 0),
-                OSSL_PARAM_construct_end()};
-            EVP_MAC_init(mctx, prk, 32, params);
-            if (i > 0)
-                EVP_MAC_update(mctx, prev, 32);
-            EVP_MAC_update(mctx, &counter, 1);
-            size_t mac_len = 32;
-            EVP_MAC_final(mctx, out, &mac_len, 32);
-            EVP_MAC_CTX_free(mctx);
-            EVP_MAC_free(mac);
 
-            secp256k1_mpt_scalar_reduce32(out, out);
-            if (!secp256k1_ec_seckey_verify(ctx, out))
+                secp256k1_mpt_scalar_reduce32(out, out);
+                if (secp256k1_ec_seckey_verify(ctx, out))
+                {
+                    accepted = 1;
+                    break;
+                }
+            }
+
+            if (!accepted)
             {
+                OPENSSL_cleanse(out, 32);
                 OPENSSL_cleanse(prk, 32);
                 OPENSSL_cleanse(nonces_out, k * 32);
                 return 0;
             }
+
             memcpy(nonces_out + i * 32, out, 32);
             memcpy(prev, out, 32);
             OPENSSL_cleanse(out, 32);


### PR DESCRIPTION
## Summary

Closes #51.

`generate_deterministic_nonces` (`src/mpt_internal.h`) previously aborted the entire nonce batch — cleansing all previously derived nonces and returning 0 — if any single nonce reduced to `0 mod n` after `secp256k1_mpt_scalar_reduce32`. The probability is negligible (~1/2^256 per call), but the failure mode is the wrong one for a deterministic derivation: the right behavior is to retry.

This is the third (and probably last in the immediate cluster) zero-value robustness fix, after #58 (sigma response on zero witness) and #61 (bulletproof t1/t2 polynomial coefficients). Touches no other files.

## Fix

Wrap the HMAC + reduce + verify step in a sub-counter retry loop:

```c
for (sub_counter = 0; sub_counter < 256; sub_counter++)
{
    ... EVP_MAC_init/update with prev || counter ...
    if (sub_counter > 0)
    {
        unsigned char sub = (unsigned char)sub_counter;
        EVP_MAC_update(mctx, &sub, 1);
    }
    ... finalize, reduce ...
    if (secp256k1_ec_seckey_verify(ctx, out)) { accepted = 1; break; }
}
```

Two design points worth flagging:

- **`sub_counter == 0` skips the extra `EVP_MAC_update`.** The no-retry path is therefore byte-identical to the prior derivation, so existing prover output is unchanged for every realistic call ever made (the retry path is statistically unreachable). No KAT churn, no test churn.
- **256-retry cap.** After 256 consecutive zero-after-reduce events (~1/2^65536) we still bail. Pragmatic upper bound on the failure-mode hierarchy: zero-probability hits are still finitely bounded.

## What the auditors said

- **GH issue #51**: Augment Code, Low severity. Direct quote: *"After `secp256k1_mpt_scalar_reduce32`, if the reduced nonce is exactly 0 (probability ~1/n ≈ 1/2^256), `secp256k1_ec_seckey_verify` rejects it and the function returns 0, wiping ALL previously generated nonces. A robust implementation should retry the derivation (e.g., increment counter and re-derive) rather than failing the entire operation."* This PR follows that recommendation literally.
- **ToB report**: does not discuss the deterministic-nonce zero-after-reduce case specifically. The closest related thread is the broader "improve point-at-infinity / zero-handling hygiene" guidance under RIPCTX-6 and the Appendix B code-quality bullets.

## Test plan

- [x] Full `ctest`: 13/13 pass (output unchanged for every realistic input).
- [x] Pre-commit hooks pass.
- [ ] **No direct unit test for the retry path.** It's statistically unreachable (~1/2^256). Forcing it would require either (a) injecting a synthetic seed engineered to land on zero — feasible only by exposing internals or with a debug compile flag, or (b) running ~2^256 iterations. Reluctant to add a debug hook just to test a structurally trivial loop. Happy to add one in a follow-up if reviewers want explicit coverage.

## Compatibility

No proof-format change, no API change, no transcript change. The retry-zero path is statistically unreachable, so existing serialized proofs and prover output are byte-for-byte unchanged.