### PR TITLE
fix: use spec-compliant BP_G / BP_H labels for bulletproof generators

### DIFF
--- a/src/bulletproof_aggregated.c
+++ b/src/bulletproof_aggregated.c
@@ -1264,10 +1264,10 @@ int secp256k1_bulletproof_prove_agg(const secp256k1_context *ctx,
 
   /* ---- 3. Generator vectors ---- */
   if (!secp256k1_mpt_get_generator_vector(ctx, G_vec, n,
-                                          (const unsigned char *)"G", 1))
+                                          (const unsigned char *)"BP_G", 4))
     goto cleanup;
   if (!secp256k1_mpt_get_generator_vector(ctx, H_vec, n,
-                                          (const unsigned char *)"H", 1))
+                                          (const unsigned char *)"BP_H", 4))
     goto cleanup;
   {
     secp256k1_pubkey U_arr[1];

--- a/src/utility/mpt_utility.cpp
+++ b/src/utility/mpt_utility.cpp
@@ -870,10 +870,12 @@ mpt_verify_aggregated_bulletproof(
     std::vector<secp256k1_pubkey> G_vec(n);
     std::vector<secp256k1_pubkey> H_vec(n);
 
-    if (secp256k1_mpt_get_generator_vector(ctx, G_vec.data(), n, (unsigned char const*)"G", 1) != 1)
+    if (secp256k1_mpt_get_generator_vector(ctx, G_vec.data(), n, (unsigned char const*)"BP_G", 4) !=
+        1)
         return -1;
 
-    if (secp256k1_mpt_get_generator_vector(ctx, H_vec.data(), n, (unsigned char const*)"H", 1) != 1)
+    if (secp256k1_mpt_get_generator_vector(ctx, H_vec.data(), n, (unsigned char const*)"BP_H", 4) !=
+        1)
         return -1;
 
     secp256k1_pubkey pk_base;

--- a/tests/test_bulletproof_agg.c
+++ b/tests/test_bulletproof_agg.c
@@ -48,9 +48,9 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
   EXPECT(G_vec && H_vec);
 
   EXPECT(secp256k1_mpt_get_generator_vector(ctx, G_vec, n,
-                                            (const unsigned char *)"G", 1));
+                                            (const unsigned char *)"BP_G", 4));
   EXPECT(secp256k1_mpt_get_generator_vector(ctx, H_vec, n,
-                                            (const unsigned char *)"H", 1));
+                                            (const unsigned char *)"BP_H", 4));
 
   /* ---- Prove ---- */
   unsigned char proof[4096];


### PR DESCRIPTION
## Summary

The bulletproof aggregated prover, the verifier-side utility caller, and the in-tree test harness all derived the `G_vec` / `H_vec` generator vectors with `secp256k1_mpt_get_generator_vector(..., "G", 1)` and `(..., "H", 1)`. Per spec these should be `"BP_G"` and `"BP_H"` (length 4), matching the existing `"BP_U"` (length 4) precedent already in use for the `U` generator inside the same prover (`bulletproof_aggregated.c:1274` and verifier `:2150`).

Independent of the open zero-value cluster (#58, #59, #61, #62) — touches a disjoint code path (HKDF generator-derivation labels rather than scalar / point arithmetic).

## Scope

Six call sites across three files, updated symmetrically so prover, verifier-side caller, and tests all derive the same generator vectors:

| File | Function | Before | After |
|---|---|---|---|
| `src/bulletproof_aggregated.c` (×2) | `secp256k1_bulletproof_prove_agg` | `"G", 1` / `"H", 1` | `"BP_G", 4` / `"BP_H", 4` |
| `src/utility/mpt_utility.cpp` (×2) | `mpt_verify_aggregated_bulletproof` | `"G", 1` / `"H", 1` | `"BP_G", 4` / `"BP_H", 4` |
| `tests/test_bulletproof_agg.c` (×2) | `run_test_case` | `"G", 1` / `"H", 1` | `"BP_G", 4` / `"BP_H", 4` |

`tests/test_ipa.c` (line 197-200) intentionally **not** changed — it tests the IPA primitive directly with its own self-consistent generator labels; the IPA test never crosses the bulletproof boundary so its labels are independent.

## Compatibility

**Wire-breaking.** Different label means different HKDF-derived generator points, so externally stored proofs against the old labels will not verify under this branch and would need to be regenerated. In-tree tests generate proofs and verify them in-process, so they continue to pass once prover, verifier, and test caller change together.

No proof-format change, no API change, no transcript change.

## Test plan

- [x] Full `ctest`: 13/13 pass.
- [x] Pre-commit hooks pass (`clang-format` reformatted one line continuation in `mpt_utility.cpp`, included in this commit).