### PR TITLE
chore: trivial cleanups (z_rb comment, redundant guards, free(NULL))

### DIFF
--- a/src/bulletproof_aggregated.c
+++ b/src/bulletproof_aggregated.c
@@ -1981,20 +1981,13 @@ cleanup:
     free(H_prime);
   }
 
-  if (al)
-    free(al);
-  if (ar)
-    free(ar);
-  if (sl)
-    free(sl);
-  if (sr)
-    free(sr);
-  if (l_vec)
-    free(l_vec);
-  if (r_vec)
-    free(r_vec);
-  if (r1_vec)
-    free(r1_vec);
+  free(al);
+  free(ar);
+  free(sl);
+  free(sr);
+  free(l_vec);
+  free(r_vec);
+  free(r1_vec);
 
   if (L_vec)
   {

--- a/src/proof_compact_standard.c
+++ b/src/proof_compact_standard.c
@@ -165,12 +165,9 @@ int secp256k1_compact_standard_prove(
   if (!secp256k1_ec_seckey_verify(ctx, r_b))
     return 0;
 
-  if (n > 0)
-  {
-    T2_vec = (secp256k1_pubkey *)malloc(sizeof(secp256k1_pubkey) * n);
-    if (!T2_vec)
-      return 0;
-  }
+  T2_vec = (secp256k1_pubkey *)malloc(sizeof(secp256k1_pubkey) * n);
+  if (!T2_vec)
+    return 0;
 
   mpt_uint64_to_scalar(m_scalar, amount);
   mpt_uint64_to_scalar(b_scalar, balance);
@@ -356,7 +353,7 @@ int secp256k1_compact_standard_prove(
   if (!compute_sigma_response(ctx, z_b, epsilon, e, b_scalar))
     goto cleanup;
 
-  /* 5. Serialize compact proof: e || z_m || z_r || z_b || z_rho || z_sk */
+  /* 5. Serialize compact proof: e || z_m || z_r || z_b || z_rb || z_sk */
   memcpy(proof_out, e, 32);
   memcpy(proof_out + 32, z_m, 32);
   memcpy(proof_out + 64, z_r, 32);
@@ -380,8 +377,7 @@ cleanup:
   OPENSSL_cleanse(z_sk, 32);
   OPENSSL_cleanse(z_rb, 32);
   OPENSSL_cleanse(z_b, 32);
-  if (T2_vec)
-    free(T2_vec);
+  free(T2_vec);
   return ok;
 }
 
@@ -416,7 +412,7 @@ int secp256k1_compact_standard_verify(
   secp256k1_pubkey H;
   int ok = 0;
 
-  /* 1. Deserialize: e || z_m || z_r || z_b || z_rho || z_sk */
+  /* 1. Deserialize: e || z_m || z_r || z_b || z_rb || z_sk */
   memcpy(e, proof, 32);
   memcpy(z_m, proof + 32, 32);
   memcpy(z_r, proof + 64, 32);
@@ -442,12 +438,9 @@ int secp256k1_compact_standard_verify(
   if (!secp256k1_ec_seckey_verify(ctx, z_b))
     return 0;
 
-  if (n > 0)
-  {
-    T2_vec = (secp256k1_pubkey *)malloc(sizeof(secp256k1_pubkey) * n);
-    if (!T2_vec)
-      return 0;
-  }
+  T2_vec = (secp256k1_pubkey *)malloc(sizeof(secp256k1_pubkey) * n);
+  if (!T2_vec)
+    return 0;
 
   if (!secp256k1_mpt_get_h_generator(ctx, &H))
     goto cleanup;
@@ -563,7 +556,6 @@ int secp256k1_compact_standard_verify(
 cleanup:
   OPENSSL_cleanse(neg_e, 32);
   /* z_*, e, e_prime are public proof values — intentionally not cleansed */
-  if (T2_vec)
-    free(T2_vec);
+  free(T2_vec);
   return ok;
 }


### PR DESCRIPTION
Three small, no-behavior-change cleanups bundled into one PR for fast review.

## What this changes

### 1. Fix `z_rho` -> `z_rb` in serialization comments (closes #44)

`src/proof_compact_standard.c:359, :419` — the comment labelled offset 128 of the proof as `z_rho`, but the field is `z_rb` (the response for the balance randomness `r_b`). The compact standard proof has witnesses `(r, m, sk_A, r_b, b)` — there is no `rho` term — so the label was misleading. Pure comment fix.

### 2. Drop redundant `if (n > 0)` after `MPT_ARG_CHECK(n > 0)` (closes #47)

`src/proof_compact_standard.c:168-173, :445-450` — both the prover and verifier already short-circuit out at the top via `MPT_ARG_CHECK(n > 0)`. The inner `if (n > 0) { malloc; }` block is dead code: control only reaches it when `n > 0`. Replaced with the unconditional `malloc + NULL check`.

### 3. Drop `if (p) free(p)` guards (addresses ToB Appendix B / B2; umbrella #64)

`free(NULL)` has been a well-defined no-op since C89, so the `if (p) free(p);` guard is dead code. Cleaned up:

- `src/bulletproof_aggregated.c:1984-1997` — 7 guards (`al`, `ar`, `sl`, `sr`, `l_vec`, `r_vec`, `r1_vec`)
- `src/proof_compact_standard.c:383-384, :566-567` — 2 guards (`T2_vec` in prover and verifier)

The remaining `if (p) { OPENSSL_cleanse(p, ...); free(p); }` blocks were intentionally left alone — those wrap a real cleanse on a non-NULL pointer (cleanse on NULL with non-zero length would be UB), so the guard is load-bearing there.

## Provenance

- #44, #47: Sonnet-4.6 audit (BUG-08, BUG-13).
- B2: Trail of Bits, *XRP Ledger Confidential Transfer — Code Review*, Comprehensive Report with Fix Review, April 2026, Appendix B (Code Quality Issues), bullet B2.

## Testing

- `cmake --build build-debug` — clean
- `ctest` — 10/10 pass
- `pre-commit run --all-files` — all hooks pass