### PR TITLE
fix: defensive arg checks for scalar_inverse and get_generator_vector

### DIFF
--- a/src/commitments.c
+++ b/src/commitments.c
@@ -168,6 +168,10 @@ int secp256k1_mpt_get_generator_vector(const secp256k1_context *ctx,
 {
   MPT_ARG_CHECK(ctx != NULL);
   MPT_ARG_CHECK(vec != NULL);
+  /* The per-point derivation indexes generators with a uint32_t counter
+   * (`hash_to_point_nums(..., uint32_t index)`); reject lengths that would
+   * silently truncate when cast. */
+  MPT_ARG_CHECK(n <= UINT32_MAX);
   /* label is optional (NULL means use default NUMS derivation) */
 
   for (uint32_t i = 0; i < (uint32_t)n; i++)

--- a/src/mpt_scalar.c
+++ b/src/mpt_scalar.c
@@ -85,6 +85,15 @@ void secp256k1_mpt_scalar_inverse(unsigned char *res, const unsigned char *in)
 {
   secp256k1_scalar s;
   secp256k1_scalar_set_b32(&s, in, NULL);
+  /* libsecp256k1's scalar_inverse returns 0 on zero input. Make that
+   * contract explicit here so callers can't accidentally rely on
+   * unspecified internal behaviour: zero in -> zero out. */
+  if (secp256k1_scalar_is_zero(&s))
+  {
+    memset(res, 0, 32);
+    OPENSSL_cleanse(&s, sizeof(s));
+    return;
+  }
   secp256k1_scalar_inverse(&s, &s);
   secp256k1_scalar_get_b32(res, &s);
 


### PR DESCRIPTION
Two small defensive additions, both flagged by Trail of Bits Code Review (April 2026), Appendix B (Code Quality Issues).

## What this changes

### 1. Bound-check `n` in `get_generator_vector` (closes #66 / B7)

`src/commitments.c`. The function takes a generator-vector length `n` as `size_t`, but the per-point derivation indexes generators with a `uint32_t` counter via `secp256k1_mpt_hash_to_point_nums(..., uint32_t index)`. The loop header `for (uint32_t i = 0; i < (uint32_t)n; i++)` silently truncates on 64-bit platforms when `n > UINT32_MAX`, producing a vector of the wrong size with no error.

Added `MPT_ARG_CHECK(n <= UINT32_MAX)` so the truncation point becomes an explicit failure at the API boundary rather than an silent off-by-2^32. Domain-meaningful upper bound (`BP_TOTAL_BITS(BP_MAX_VALUES) = 256`) would also work, but the API is general-purpose, so the wider `UINT32_MAX` keeps it.

### 2. Make zero-input contract explicit in `scalar_inverse` (closes #67 / B8)

`src/mpt_scalar.c`. `secp256k1_mpt_scalar_inverse` is `void`-returning, so a literal `MPT_ARG_CHECK` (which returns `0` from the calling function) doesn't fit. Instead, pinned the zero-input behaviour at the wrapper boundary: `zero in -> zero out`, with an explicit early return.

libsecp256k1's `scalar_inverse` already returns the zero scalar on zero input, but pinning that contract at the wrapper level keeps callers from accidentally relying on an unspecified internal detail of libsecp.

**Trade-off note**: a stricter fix — propagate failure to the caller via a return code — would require changing the public signature from `void` to `int`. Deferring that as out of scope for this PR; happy to do it as a follow-up if reviewers prefer.

## Provenance

Trail of Bits, *XRP Ledger Confidential Transfer — Code Review*, Comprehensive Report with Fix Review, April 2026, Appendix B (Code Quality Issues), bullets B7 and B8.

## Testing

- `cmake --build build-debug` — clean
- `ctest` — 10/10 pass
- `pre-commit run --all-files` — all hooks pass