### PR TITLE
docs: explain NULL overflow discard in mpt_scalar helpers

### DIFF
--- a/src/mpt_scalar.c
+++ b/src/mpt_scalar.c
@@ -32,6 +32,14 @@
  * @warning These functions operate on 32-byte big-endian scalars. Inputs must
  * be properly reduced or handled by `secp256k1_mpt_scalar_reduce32` before use
  * if they might exceed \f$ n \f$.
+ *
+ * @note Every `secp256k1_scalar_set_b32` call below passes `NULL` for the
+ * overflow output parameter, intentionally discarding any signal that a
+ * modular reduction occurred. This matches the @warning above: callers are
+ * contracted to pre-reduce their inputs (or invoke
+ * `secp256k1_mpt_scalar_reduce32` explicitly when reduction is the intent).
+ * Callers that need to validate well-formedness must do so before invoking
+ * these helpers.
  */
 
 #include "secp256k1_mpt.h"
@@ -55,6 +63,7 @@ void secp256k1_mpt_scalar_add(unsigned char *res, const unsigned char *a,
                               const unsigned char *b)
 {
   secp256k1_scalar s_res, s_a, s_b;
+  /* Overflow output discarded; see file-level @note. */
   secp256k1_scalar_set_b32(&s_a, a, NULL);
   secp256k1_scalar_set_b32(&s_b, b, NULL);
   secp256k1_scalar_add(&s_res, &s_a, &s_b);
@@ -70,6 +79,7 @@ void secp256k1_mpt_scalar_mul(unsigned char *res, const unsigned char *a,
                               const unsigned char *b)
 {
   secp256k1_scalar s_res, s_a, s_b;
+  /* Overflow output discarded; see file-level @note. */
   secp256k1_scalar_set_b32(&s_a, a, NULL);
   secp256k1_scalar_set_b32(&s_b, b, NULL);
   secp256k1_scalar_mul(&s_res, &s_a, &s_b);
@@ -84,6 +94,7 @@ void secp256k1_mpt_scalar_mul(unsigned char *res, const unsigned char *a,
 void secp256k1_mpt_scalar_inverse(unsigned char *res, const unsigned char *in)
 {
   secp256k1_scalar s;
+  /* Overflow output discarded; see file-level @note. */
   secp256k1_scalar_set_b32(&s, in, NULL);
   secp256k1_scalar_inverse(&s, &s);
   secp256k1_scalar_get_b32(res, &s);
@@ -95,6 +106,7 @@ void secp256k1_mpt_scalar_inverse(unsigned char *res, const unsigned char *in)
 void secp256k1_mpt_scalar_negate(unsigned char *res, const unsigned char *in)
 {
   secp256k1_scalar s;
+  /* Overflow output discarded; see file-level @note. */
   secp256k1_scalar_set_b32(&s, in, NULL);
   secp256k1_scalar_negate(&s, &s);
   secp256k1_scalar_get_b32(res, &s);
@@ -107,6 +119,9 @@ void secp256k1_mpt_scalar_reduce32(unsigned char out32[32],
                                    const unsigned char in32[32])
 {
   secp256k1_scalar s;
+  /* Overflow output discarded by design: this function exists specifically
+   * to reduce its input modulo n. The reduction is the contract, not a
+   * side-effect to surface to the caller. */
   secp256k1_scalar_set_b32(&s, in32, NULL);
   secp256k1_scalar_get_b32(out32, &s);
 


### PR DESCRIPTION
## Summary

Closes #65 (ToB Code Review April 2026, Appendix B bullet **B5**).

The five `secp256k1_scalar_set_b32` call sites in `src/mpt_scalar.c` pass `NULL` for the overflow output parameter, which silently discards the signal that a modular reduction occurred on the input. This is intentional — the file-level `@warning` already contracts callers to pre-reduce their inputs — but the design choice was previously *implicit*, leaving an audit-time question about whether modular truncation was a hidden bug.

This PR makes the discard explicit:
- **File-level `@note`** documenting the convention across all five helpers.
- **Inline comment** at each call site (`_add`, `_mul`, `_inverse`, `_negate`).
- **Distinct rationale** at `secp256k1_mpt_scalar_reduce32` where the discard *is* the contract (the function's whole purpose is to reduce its input).

Doc-only change; no functional or ABI impact.

## Test plan

- [x] `cmake --build build-debug` clean
- [x] `ctest` 10/10 pass (no logic change)
- [x] `pre-commit run --all-files` all hooks pass