### PR TITLE
fix(elgamal): chain-hash only previous output in rejection sampling

### DIFF
--- a/src/elgamal.c
+++ b/src/elgamal.c
@@ -274,21 +274,24 @@ int generate_canonical_encrypted_zero(
   memcpy(hash_input + 7, account_id, 20);
   memcpy(hash_input + 27, mpt_issuance_id, 24);
 
-  /* Rejection sampling loop to ensure scalar is valid */
-  do
+  /* Initial hash of the domain-tagged input. */
+  unsigned int md_len = 32;
+  if (EVP_Digest(hash_input, 51, deterministic_scalar, &md_len, EVP_sha256(),
+                 NULL) != 1)
+    return 0;
+
+  /* Rejection sampling: chain-hash the 32-byte previous output until it is a
+   * valid secp256k1 scalar. The probability of needing more than one iteration
+   * is ~2^-128, so in practice the loop body executes zero times. The chain
+   * deliberately hashes only the previous output (not the full 51-byte
+   * domain-tagged buffer): mixing stale tail bytes from `hash_input` would
+   * yield a non-standard construction without any security benefit. */
+  while (!secp256k1_ec_seckey_verify(ctx, deterministic_scalar))
   {
-    unsigned int md_len = 32;
-    if (EVP_Digest(hash_input, 51, deterministic_scalar, &md_len, EVP_sha256(),
-                   NULL) != 1)
+    if (EVP_Digest(deterministic_scalar, 32, deterministic_scalar, &md_len,
+                   EVP_sha256(), NULL) != 1)
       return 0;
-
-    if (secp256k1_ec_seckey_verify(ctx, deterministic_scalar))
-      break;
-
-    // Re-hash the output for next iteration (chain method for determinism)
-    memcpy(hash_input, deterministic_scalar, 32);
-
-  } while (1);
+  }
 
   ret = secp256k1_elgamal_encrypt(ctx, enc_zero_c1, enc_zero_c2, pubkey, 0,
                                   deterministic_scalar);


### PR DESCRIPTION
## Summary

The rejection-sampling loop in `generate_canonical_encrypted_zero` (`src/elgamal.c:278-291`) had a subtle hash-chain bug:

- The 51-byte `hash_input` buffer is laid out as `"EncZero" || account_id (20) || mpt_issuance_id (24)`.
- On a rejection, the loop copied the 32-byte hash output into `hash_input[0..31]`, then re-hashed all 51 bytes.
- That left bytes 32-50 as **stale residue** from the original `account_id`/`mpt_issuance_id` data.
- Result: a non-standard, undocumented hash chain. Still deterministic, still secure in practice, but doesn't match any documented construction (HKDF, plain hash chain, etc.) — exactly the kind of thing an audit will flag.

Both Claude Sonnet 4.6 (BUG-07) and Augment Code (Bug 5) flagged this independently in #42.

## Fix

Restructure to: initial hash of the full domain-tagged input, then a rejection-sampling loop that chain-hashes only the **32-byte previous output**. The loop body is reached with probability ~2^-128 (the gap between secp256k1's group order and 2^256), so this is purely an audit-cleanliness fix with no observable behavior change for any realistic input.

## Test plan

- [x] Build clean (no warnings)
- [x] `ctest` — all 10 tests pass (including `test_elgamal`)
- [x] `pre-commit run --all-files` — all hooks pass

Closes #42.