### PR TITLE
fix(nonce-gen): check EVP_MAC return values in generate_deterministic_nonces

### DIFF
--- a/src/mpt_internal.h
+++ b/src/mpt_internal.h
@@ -163,26 +163,31 @@ generate_deterministic_nonces(
     {
         EVP_MAC* mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
         if (!mac)
+        {
+            OPENSSL_cleanse(salt, 32);
             return 0;
+        }
         EVP_MAC_CTX* mctx = EVP_MAC_CTX_new(mac);
         if (!mctx)
         {
             EVP_MAC_free(mac);
+            OPENSSL_cleanse(salt, 32);
             return 0;
         }
         OSSL_PARAM params[] = {
             OSSL_PARAM_construct_utf8_string("digest", "SHA256", 0), OSSL_PARAM_construct_end()};
-        if (!EVP_MAC_init(mctx, salt, 32, params))
+        size_t mac_len = 32;
+        if (!EVP_MAC_init(mctx, salt, 32, params) || !EVP_MAC_update(mctx, witness, witness_len) ||
+            !EVP_MAC_update(mctx, statement_hash, 32) ||
+            !EVP_MAC_update(mctx, (unsigned char const*)domain, domain_len) ||
+            !EVP_MAC_final(mctx, prk, &mac_len, 32))
         {
             EVP_MAC_CTX_free(mctx);
             EVP_MAC_free(mac);
+            OPENSSL_cleanse(salt, 32);
+            OPENSSL_cleanse(prk, 32);
             return 0;
         }
-        EVP_MAC_update(mctx, witness, witness_len);
-        EVP_MAC_update(mctx, statement_hash, 32);
-        EVP_MAC_update(mctx, (unsigned char const*)domain, domain_len);
-        size_t mac_len = 32;
-        EVP_MAC_final(mctx, prk, &mac_len, 32);
         EVP_MAC_CTX_free(mctx);
         EVP_MAC_free(mac);
     }
@@ -225,17 +230,22 @@ generate_deterministic_nonces(
                 OSSL_PARAM params[] = {
                     OSSL_PARAM_construct_utf8_string("digest", "SHA256", 0),
                     OSSL_PARAM_construct_end()};
-                EVP_MAC_init(mctx, prk, 32, params);
-                if (i > 0)
-                    EVP_MAC_update(mctx, prev, 32);
-                EVP_MAC_update(mctx, &counter, 1);
-                if (sub_counter > 0)
-                {
-                    unsigned char sub = (unsigned char)sub_counter;
-                    EVP_MAC_update(mctx, &sub, 1);
-                }
                 size_t mac_len = 32;
-                EVP_MAC_final(mctx, out, &mac_len, 32);
+                unsigned char sub = (unsigned char)sub_counter;
+                if (!EVP_MAC_init(mctx, prk, 32, params) ||
+                    (i > 0 && !EVP_MAC_update(mctx, prev, 32)) ||
+                    !EVP_MAC_update(mctx, &counter, 1) ||
+                    (sub_counter > 0 && !EVP_MAC_update(mctx, &sub, 1)) ||
+                    !EVP_MAC_final(mctx, out, &mac_len, 32))
+                {
+                    EVP_MAC_CTX_free(mctx);
+                    EVP_MAC_free(mac);
+                    OPENSSL_cleanse(out, 32);
+                    OPENSSL_cleanse(prev, 32);
+                    OPENSSL_cleanse(prk, 32);
+                    OPENSSL_cleanse(nonces_out, k * 32);
+                    return 0;
+                }
                 EVP_MAC_CTX_free(mctx);
                 EVP_MAC_free(mac);
 


### PR DESCRIPTION
Closes #40.

## Summary

The unchecked `EVP_MAC_init` / `EVP_MAC_update` / `EVP_MAC_final` calls in `generate_deterministic_nonces` (`src/mpt_internal.h`) could silently produce garbage `prk` or per-round `out`. Those values then flow into `secp256k1_mpt_scalar_reduce32` and `secp256k1_ec_seckey_verify`, which may accept them as nonces — and a predictable/weak nonce in a sigma protocol directly leaks the secret witness.

Both Sonnet 4.6 (BUG-04) and Augment (Bug 3 / Bug 4) flagged this independently.

## Fix

Each EVP_MAC call is now checked. On failure: free the MAC context and cleanse all secret-bearing buffers.

**Extract phase:** chained `if (!init || !update || !update || !update || !final)` with cleanup `(EVP_MAC_CTX_free, EVP_MAC_free, OPENSSL_cleanse salt, OPENSSL_cleanse prk)`. Also added `OPENSSL_cleanse(salt, 32)` to the existing `EVP_MAC_fetch` and `EVP_MAC_CTX_new` failure paths for consistency.

**Expand inner loop:** chained check covering `init || prev_update || counter_update || sub_update || final`. The conditional sites (`if (i > 0) update(prev, ...)` and `if (sub_counter > 0) update(&sub, ...)`) become `(i > 0 && !update(...))` so short-circuit preserves the skip-when-zero semantics. Cleanup adds `OPENSSL_cleanse(out, 32)` to the existing `(prev, prk, nonces_out)` set since `out` may be partially written by a failed `EVP_MAC_final`.

## Test plan

- [x] Build clean (no warnings)
- [x] `ctest` — all 10 tests pass
- [x] `pre-commit run --all-files` — all hooks pass

## Provenance

- Sonnet 4.6 audit: BUG-04
- Augment audit: Bug 3 (Expand phase), Bug 4 (Extract phase)