### PR TITLE
docs: buffer alignment, context thread safety, salt rationale

### DIFF
--- a/src/mpt_internal.h
+++ b/src/mpt_internal.h
@@ -155,7 +155,27 @@ generate_deterministic_nonces(
     if (k == 0 || k > 8)
         return 0;
 
-    /* Fresh entropy for defense-in-depth */
+    /* Fresh entropy for defense-in-depth.
+     *
+     * The HKDF Extract step here uses a random `salt` rather than the more
+     * common all-zero salt. The deterministic-nonce derivation
+     * (`HMAC(prk, witness || statement_hash || domain)`) is already collision-
+     * resistant under HMAC's PRF assumption, so the salt is not load-bearing
+     * for soundness. Its purpose is purely defense-in-depth:
+     *
+     *  - If a witness scalar were ever reused across two proofs (e.g., a
+     *    duplicate amount + same blinding factor due to a caller bug), an
+     *    all-zero-salt construction would produce identical `prk` and
+     *    identical nonce streams. The fresh per-call salt instead randomizes
+     *    `prk` so colliding (witness, statement_hash) inputs still yield
+     *    independent nonce streams.
+     *  - It also provides a hedge against any future weakness in the witness/
+     *    statement encoding that would otherwise allow an attacker to predict
+     *    or correlate `prk` across proofs.
+     *
+     * Note that the salt itself is NOT included in the proof; it only affects
+     * the prover's nonce derivation. The Fiat-Shamir transcript binds the
+     * resulting commitment values, so verifier soundness is unaffected. */
     if (RAND_bytes(salt, 32) != 1)
         return 0;
 

--- a/src/utility/mpt_utility.cpp
+++ b/src/utility/mpt_utility.cpp
@@ -31,7 +31,21 @@
 extern "C" {
 /**
  * Context for secp256k1 operations.
- * Initialized once and reused across all operations to optimize performance
+ *
+ * Initialized once on first call and reused across all operations to optimize
+ * performance.
+ *
+ * Thread safety: a function-local `static` instance gives C++11-guaranteed
+ * thread-safe one-time initialization. Once constructed, the returned context
+ * is safe to share across threads for proof generation and verification:
+ * libsecp256k1 documents that all functions taking a `secp256k1_context const*`
+ * are thread-safe, and the entry points in this file (prove/verify) only use
+ * the context in that read-only mode.
+ *
+ * Callers must NOT invoke libsecp256k1 functions that mutate the context
+ * (e.g., `secp256k1_context_randomize`, `secp256k1_context_destroy`)
+ * concurrently with proof/verify operations on other threads. The constructor
+ * already performs the one randomize at init; no further mutation is needed.
  */
 secp256k1_context*
 mpt_secp256k1_context()
@@ -77,7 +91,26 @@ mpt_secp256k1_context()
 
 /**
  * @internal
- * Private helper to generate aggregated bulletproofs
+ * Private helper to generate aggregated bulletproofs.
+ *
+ * @param values         Array of `m` plaintext amounts to range-prove.
+ * @param blinding_ptrs  Array of `m` pointers to 32-byte Pedersen blinding
+ *                       factors. Each entry must be non-NULL.
+ * @param m              Aggregation count. Restricted to `{1, 2}` (see comment
+ *                       in body).
+ * @param context_hash   32-byte transaction-context hash bound into the
+ *                       Fiat--Shamir transcript.
+ * @param out_proof      Caller-allocated output buffer for the serialized
+ *                       proof. Treated as a raw byte buffer (`uint8_t*`):
+ *                       no alignment requirement beyond a `uint8_t*`. Must
+ *                       hold at least `kMPT_SINGLE_BULLETPROOF_SIZE` bytes
+ *                       when `m == 1`, or `kMPT_DOUBLE_BULLETPROOF_SIZE`
+ *                       bytes when `m == 2`.
+ * @param out_len        On entry: the size of `out_proof` in bytes. On exit:
+ *                       the number of bytes actually written. Must be
+ *                       non-NULL.
+ * @return 0 on success, -1 on any failure (invalid args, generator lookup
+ *         failure, prover failure, or unexpected serialized length).
  */
 static int
 mpt_get_bulletproof_agg(


### PR DESCRIPTION
Three small doc-only additions, all flagged by the Sonnet 4.6 audit. No behavior change.

## What this changes

### 1. `mpt_get_bulletproof_agg` — Doxygen block (closes #32)

`src/utility/mpt_utility.cpp`. Added a parameter-by-parameter Doxygen block. The user-visible contract that was missing: `out_proof` is treated as a raw byte buffer (`uint8_t*`) and has no alignment requirement beyond a `uint8_t*`. Also documents the size requirement in terms of `kMPT_{SINGLE,DOUBLE}_BULLETPROOF_SIZE`, the `m ∈ {1, 2}` restriction (cross-references the inline comment from #46/PR #72), and the return-code semantics.

### 2. `mpt_secp256k1_context()` — thread safety (closes #34)

`src/utility/mpt_utility.cpp`. Expanded the comment to spell out:

- **One-time init**: function-local `static ContextHolder` gets C++11-guaranteed thread-safe construction. First-thread-in does the create + randomize; subsequent threads see the constructed pointer.
- **Read-only sharing is safe**: libsecp256k1 documents that all functions taking a `secp256k1_context const*` are thread-safe, and every prove/verify entry point in this file uses the context that way (most call sites already typed it as `secp256k1_context const*`).
- **Caller contract**: must NOT call `secp256k1_context_randomize` / `secp256k1_context_destroy` (or any other mutating context API) concurrently with prove/verify. The constructor already does the one randomize; nothing else should mutate the context.

### 3. `generate_deterministic_nonces` — salt rationale (closes #36)

`src/mpt_internal.h`. Expanded the "Fresh entropy for defense-in-depth" comment to actually explain what defense-in-depth means here:

- **Soundness does not depend on the salt.** The deterministic-nonce derivation `HMAC(prk, witness || statement_hash || domain)` is already collision-resistant under HMAC's PRF assumption. A standard HKDF Extract with all-zero salt would be sound.
- **What the salt buys**: independence under accidental witness reuse (caller-bug scenario where the same witness + statement gets fed twice; with zero salt that would yield identical `prk` and identical nonce streams; with fresh salt it doesn't), plus a hedge against any future weakness in the witness/statement encoding.
- **Verifier soundness is unaffected**: the salt is prover-local and never appears in the proof. The Fiat-Shamir transcript binds the resulting commitment values, so different salts just mean different (but equally valid) proofs.

## Test plan

- [x] `cmake --build build-debug` clean, no warnings
- [x] `ctest` — 10/10 pass
- [x] `pre-commit run --all-files` — all hooks pass

## Provenance

Issues #32, #34, #36: Sonnet 4.6 audit (BUG-9, BUG-10, BUG-11 in original numbering).