### PR TITLE
fix(bp-verifier): centralize y_*/y_block_sum cleanup at fail: label

### DIFF
--- a/src/bulletproof_aggregated.c
+++ b/src/bulletproof_aggregated.c
@@ -2093,6 +2093,14 @@ int secp256k1_bulletproof_verify_agg(
     return 0;
   }
 
+  /* Heap allocations whose lifetime spans multiple goto-fail sites.
+   * Declared here, ahead of the first `goto fail`, and NULL-initialized so the
+   * centralized free at the `fail:` label is a no-op when execution exits
+   * before the actual malloc. */
+  unsigned char *y_powers = NULL;
+  unsigned char *y_inv_powers = NULL;
+  unsigned char (*y_block_sum)[32] = NULL;
+
   unsigned char a_final[32], b_final[32];
   unsigned char t_hat[32], tau_x[32], mu[32];
 
@@ -2166,8 +2174,6 @@ int secp256k1_bulletproof_verify_agg(
   size_t slen;
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
   int fs_ok = 0;
-  unsigned char *y_powers = NULL;
-  unsigned char *y_inv_powers = NULL;
 
   if (!mdctx)
     goto fail;
@@ -2264,11 +2270,7 @@ int secp256k1_bulletproof_verify_agg(
   y_powers = (unsigned char *)malloc(n * 32);
   y_inv_powers = (unsigned char *)malloc(n * 32);
   if (!y_powers || !y_inv_powers)
-  {
-    free(y_powers);
-    free(y_inv_powers);
     goto fs_fail;
-  }
 
   unsigned char y_inv[32];
   scalar_vector_powers(ctx, (unsigned char (*)[32])y_powers, y, n);
@@ -2299,13 +2301,7 @@ int secp256k1_bulletproof_verify_agg(
   secp256k1_mpt_scalar_reduce32(x, x);
 
   if (!secp256k1_ec_seckey_verify(ctx, x))
-  {
-    free(y_powers);
-    y_powers = NULL;
-    free(y_inv_powers);
-    y_inv_powers = NULL;
     goto fs_fail;
-  }
 
   fs_ok = 1;
 
@@ -2324,13 +2320,9 @@ fs_fail:
    */
 
   /* --- delta(y,z) for aggregation --- */
-  unsigned char (*y_block_sum)[32] = (unsigned char (*)[32])malloc(m * 32);
+  y_block_sum = (unsigned char (*)[32])malloc(m * 32);
   if (!y_block_sum)
-  {
-    free(y_powers);
-    free(y_inv_powers);
     goto fail;
-  }
 
   unsigned char two_sum[32];
   compute_delta_scalars(ctx, y_block_sum, two_sum, y, m);
@@ -2379,9 +2371,6 @@ fs_fail:
     {
       if (!secp256k1_ec_pubkey_create(ctx, &tG, t_hat))
       {
-        free(y_block_sum);
-        free(y_powers);
-        free(y_inv_powers);
         goto fail;
       }
       have_t = 1;
@@ -2391,9 +2380,6 @@ fs_fail:
       tauH = *pk_base;
       if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tauH, tau_x))
       {
-        free(y_block_sum);
-        free(y_powers);
-        free(y_inv_powers);
         goto fail;
       }
       have_tau = 1;
@@ -2403,9 +2389,6 @@ fs_fail:
       const secp256k1_pubkey *pts[2] = {&tG, &tauH};
       if (!secp256k1_ec_pubkey_combine(ctx, &LHS, pts, 2))
       {
-        free(y_block_sum);
-        free(y_powers);
-        free(y_inv_powers);
         goto fail;
       }
     }
@@ -2419,9 +2402,6 @@ fs_fail:
     }
     else
     {
-      free(y_block_sum);
-      free(y_powers);
-      free(y_inv_powers);
       goto fail;
     }
   }
@@ -2444,16 +2424,10 @@ fs_fail:
         tmpP = commitment_C_vec[j];
         if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tmpP, z_j2))
         {
-          free(y_block_sum);
-          free(y_powers);
-          free(y_inv_powers);
           goto fail;
         }
         if (!add_term(ctx, &acc, &inited, &tmpP))
         {
-          free(y_block_sum);
-          free(y_powers);
-          free(y_inv_powers);
           goto fail;
         }
       }
@@ -2476,16 +2450,10 @@ fs_fail:
       tmpP = T1;
       if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tmpP, x))
       {
-        free(y_block_sum);
-        free(y_powers);
-        free(y_inv_powers);
         goto fail;
       }
       if (!add_term(ctx, &acc, &inited, &tmpP))
       {
-        free(y_block_sum);
-        free(y_powers);
-        free(y_inv_powers);
         goto fail;
       }
     }
@@ -2499,17 +2467,11 @@ fs_fail:
       if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tmpP, x_sq))
       {
         OPENSSL_cleanse(x_sq, 32);
-        free(y_block_sum);
-        free(y_powers);
-        free(y_inv_powers);
         goto fail;
       }
       if (!add_term(ctx, &acc, &inited, &tmpP))
       {
         OPENSSL_cleanse(x_sq, 32);
-        free(y_block_sum);
-        free(y_powers);
-        free(y_inv_powers);
         goto fail;
       }
     }
@@ -2517,9 +2479,6 @@ fs_fail:
 
     if (!inited)
     {
-      free(y_block_sum);
-      free(y_powers);
-      free(y_inv_powers);
       goto fail;
     }
     RHS = acc;
@@ -2527,9 +2486,6 @@ fs_fail:
 
   if (!pubkey_equal(ctx, &LHS, &RHS))
   {
-    free(y_block_sum);
-    free(y_powers);
-    free(y_inv_powers);
     goto fail;
   }
 
@@ -2613,9 +2569,6 @@ fs_fail:
     secp256k1_pubkey xS = S;
     if (!secp256k1_ec_pubkey_tweak_mul(ctx, &xS, x))
     {
-      free(y_block_sum);
-      free(y_powers);
-      free(y_inv_powers);
       goto fail;
     }
 
@@ -2632,9 +2585,6 @@ fs_fail:
   memcpy(neg_z, z, 32);
   if (!secp256k1_ec_seckey_negate(ctx, neg_z))
   {
-    free(y_block_sum);
-    free(y_powers);
-    free(y_inv_powers);
     goto fail;
   }
 
@@ -2711,9 +2661,6 @@ fs_fail:
       if (!secp256k1_ec_pubkey_tweak_mul(ctx, &Q, t_hat_ux))
       {
         OPENSSL_cleanse(t_hat_ux, 32);
-        free(y_block_sum);
-        free(y_powers);
-        free(y_inv_powers);
         goto fail;
       }
       const secp256k1_pubkey *pts2[2] = {&P, &Q};
@@ -2731,9 +2678,6 @@ fs_fail:
     memcpy(neg_mu, mu, 32);
     if (!secp256k1_ec_seckey_negate(ctx, neg_mu))
     {
-      free(y_block_sum);
-      free(y_powers);
-      free(y_inv_powers);
       goto fail;
     }
 
@@ -2741,9 +2685,6 @@ fs_fail:
     if (!secp256k1_ec_pubkey_tweak_mul(ctx, &mu_term, neg_mu))
     {
       OPENSSL_cleanse(neg_mu, 32);
-      free(y_block_sum);
-      free(y_powers);
-      free(y_inv_powers);
       goto fail;
     }
     OPENSSL_cleanse(neg_mu, 32);
@@ -2760,9 +2701,6 @@ fs_fail:
       (secp256k1_pubkey *)malloc(n * sizeof(secp256k1_pubkey));
   if (!Hprime)
   {
-    free(y_block_sum);
-    free(y_powers);
-    free(y_inv_powers);
     goto fail;
   }
 
@@ -2773,9 +2711,6 @@ fs_fail:
             ctx, &Hprime[k], (const unsigned char *)(y_inv_powers + 32 * k)))
     {
       free(Hprime);
-      free(y_block_sum);
-      free(y_powers);
-      free(y_inv_powers);
       goto fail;
     }
   }
@@ -2795,6 +2730,11 @@ fs_fail:
   return ok ? 1 : 0;
 
 fail:
+  /* Centralized cleanup. All goto-fail sites land here; pointers that have
+   * not yet been allocated are still NULL, and free(NULL) is a no-op. */
+  free(y_block_sum);
+  free(y_powers);
+  free(y_inv_powers);
   free(L_vec);
   free(R_vec);
   return 0;


### PR DESCRIPTION
Closes #75.

## The bug

`secp256k1_bulletproof_verify_agg` allocates three heap buffers — `y_powers`, `y_inv_powers`, `y_block_sum` — that are needed by the polynomial-identity check and the IPA verification step. The `fail:` label freed only `L_vec` and `R_vec`, so every `goto fail` site reached after those three were allocated had to free them inline.

Most sites did. These didn't:

- `if (!mdctx) goto fail` (ipa-transcript-id block — `EVP_MD_CTX_new` failure)
- `if (!ok) goto fail` after `ipa_tid_cleanup` (any `EVP_DigestUpdate`/serialize failure inside the ipa-transcript-id block)
- `derive_ipa_binding_challenge` failure
- `secp256k1_ec_pubkey_combine` failure on `P += xS`
- The `Gi` term inside the `j × i` MSM loop: `tweak_mul` failure, `pubkey_combine` failure
- The `Hi` term inside the same loop: two `tweak_mul` failures, one `pubkey_combine` failure
- `pubkey_combine` failure on the `(t_hat * ux) * U` accumulation
- `pubkey_combine` failure on the `mu * pk_base` subtraction
- The `delta * G` block (`pubkey_create` and `add_term` failures)

If any of these branches fired, ~`32 * (2n + m)` bytes of heap leaked (with `n = 64 * m`, `m ∈ {1, 2}` in current callers, that's roughly 4–9 KB per failed verify).

## The fix

Option 1 from the issue (preferred refactor, cleanest):

1. **Move declarations to the top.** `y_powers`, `y_inv_powers`, `y_block_sum` are declared right after the `L_vec`/`R_vec` malloc check, NULL-initialized. Now they're in scope at *every* `goto fail` site, including the early proof-parse / scalar-validate / `U`-derivation paths that occur before any of the buffers are actually allocated.
2. **Move frees to `fail:`.** The label now does `free(y_block_sum); free(y_powers); free(y_inv_powers); free(L_vec); free(R_vec);`. `free(NULL)` has been a no-op since C89, so paths that fail before the actual `malloc` are still safe.
3. **Drop all 19 inline 3-free blocks** before `goto fail`. Existing in-scope cleanses (`OPENSSL_cleanse` on `x_sq`, `t_hat_ux`, `neg_mu`) are preserved in place.

Net diff: **+14 / −74**. No behavior change on the success path.

`Hprime` is intentionally not centralized — it has a single goto-fail site that already frees it correctly, and adding it to the `fail:` cleanup would require a function-top NULL-init for no leak benefit.

## Why this matters

Confidential-Transfer verifiers run on every consensus round. A leak triggered by a malformed proof — even a rare one — accumulates across nodes and over time, and the leaked buffers contain field elements derived from the proof, which makes them mildly sensitive (no secrets, but not garbage either). The pre-fix sites are reachable by feeding a structurally-valid proof whose internal challenges happen to land on a libsecp arithmetic edge case (e.g., a `tweak_mul` operand that hits the zero scalar via Fiat-Shamir collision — astronomically rare in practice, but present in the threat model that audit reviewers exercise).

## Test plan

- [x] `cmake --build build-debug` clean
- [x] `ctest` — 10/10 pass
- [x] `pre-commit run --all-files` — all hooks pass
- [x] All goto-fail paths still reach `fail:` (verified by inspection of `git diff`)

## Provenance

Surfaced incidentally during review of PR #74 (#48 fix). Filed as #75; scope-tagged as a separate fix to keep #74's negate-consistency change minimal.

## Conflict note

`secp256k1_ec_seckey_negate` → `secp256k1_mpt_scalar_negate` migration in PR #74 touches two of the same goto-fail sites (`neg_z`, `neg_mu`). When #74 lands first, this branch will need a trivial rebase: take #74's collapsed `mpt_scalar_negate` form (which removes the entire failable block, including the goto-fail leak site itself).