### PR TITLE
refactor: replace magic 32/33 with kMPT_HALF_SHA_SIZE / kMPT_PUBKEY_SIZE in transcript helpers

### DIFF
--- a/include/secp256k1_mpt.h
+++ b/include/secp256k1_mpt.h
@@ -1,6 +1,7 @@
 #ifndef SECP256K1_MPT_H
 #define SECP256K1_MPT_H
 
+#include "mpt_protocol.h"
 #include <secp256k1.h>
 #include <stdint.h>
 

--- a/src/commitments.c
+++ b/src/commitments.c
@@ -55,8 +55,8 @@ int secp256k1_mpt_hash_to_point_nums(const secp256k1_context *ctx,
                                      const unsigned char *label,
                                      size_t label_len, uint32_t index)
 {
-  unsigned char hash[32];
-  unsigned char compressed[33];
+  unsigned char hash[kMPT_HALF_SHA_SIZE];
+  unsigned char compressed[kMPT_PUBKEY_SIZE];
   uint32_t ctr = 0;
 
   unsigned char idx_be[4] = {
@@ -115,9 +115,9 @@ int secp256k1_mpt_hash_to_point_nums(const secp256k1_context *ctx,
 
     compressed[0] =
         0x02; // Force even Y (standard convention for unique points)
-    memcpy(&compressed[1], hash, 32);
+    memcpy(&compressed[1], hash, kMPT_HALF_SHA_SIZE);
 
-    if (secp256k1_ec_pubkey_parse(ctx, out, compressed, 33) == 1)
+    if (secp256k1_ec_pubkey_parse(ctx, out, compressed, kMPT_PUBKEY_SIZE) == 1)
     {
       EVP_MD_CTX_free(mdctx);
       return 1;

--- a/src/elgamal.c
+++ b/src/elgamal.c
@@ -55,13 +55,13 @@ int secp256k1_elgamal_generate_keypair(const secp256k1_context *ctx,
 
   do
   {
-    if (RAND_bytes(privkey, 32) != 1)
+    if (RAND_bytes(privkey, kMPT_PRIVKEY_SIZE) != 1)
       return 0;
   } while (!secp256k1_ec_seckey_verify(ctx, privkey));
 
   if (!secp256k1_ec_pubkey_create(ctx, pubkey, privkey))
   {
-    OPENSSL_cleanse(privkey, 32); // Cleanup on failure
+    OPENSSL_cleanse(privkey, kMPT_PRIVKEY_SIZE); // Cleanup on failure
     return 0;
   }
   return 1;
@@ -423,7 +423,7 @@ int generate_canonical_encrypted_zero(
   memcpy(hash_input + 27, mpt_issuance_id, 24);
 
   /* Initial hash of the domain-tagged input. */
-  unsigned int md_len = 32;
+  unsigned int md_len = kMPT_HALF_SHA_SIZE;
   if (EVP_Digest(hash_input, 51, deterministic_scalar, &md_len, EVP_sha256(),
                  NULL) != 1)
     return 0;
@@ -436,8 +436,8 @@ int generate_canonical_encrypted_zero(
    * yield a non-standard construction without any security benefit. */
   while (!secp256k1_ec_seckey_verify(ctx, deterministic_scalar))
   {
-    if (EVP_Digest(deterministic_scalar, 32, deterministic_scalar, &md_len,
-                   EVP_sha256(), NULL) != 1)
+    if (EVP_Digest(deterministic_scalar, kMPT_HALF_SHA_SIZE,
+                   deterministic_scalar, &md_len, EVP_sha256(), NULL) != 1)
       return 0;
   }
 

--- a/src/proof_compact_clawback.c
+++ b/src/proof_compact_clawback.c
@@ -40,23 +40,23 @@ static const char DOMAIN_COMPACT_CLAWBACK[] = "CMPT_CLAWBACK_SIGMA";
 static int digest_update_amount_point(const secp256k1_context *ctx,
                                       EVP_MD_CTX *mdctx, uint64_t amount)
 {
-  unsigned char buf[33];
+  unsigned char buf[kMPT_PUBKEY_SIZE];
   if (amount == 0)
   {
-    memset(buf, 0, 33);
+    memset(buf, 0, kMPT_PUBKEY_SIZE);
   }
   else
   {
     secp256k1_pubkey mG;
-    size_t len = 33;
+    size_t len = kMPT_PUBKEY_SIZE;
     if (!compute_amount_point(ctx, &mG, amount))
       return 0;
     if (!secp256k1_ec_pubkey_serialize(ctx, buf, &len, &mG,
                                        SECP256K1_EC_COMPRESSED) ||
-        len != 33)
+        len != kMPT_PUBKEY_SIZE)
       return 0;
   }
-  return EVP_DigestUpdate(mdctx, buf, 33);
+  return EVP_DigestUpdate(mdctx, buf, kMPT_PUBKEY_SIZE);
 }
 
 static int compute_compact_clawback_challenge(
@@ -66,8 +66,8 @@ static int compute_compact_clawback_challenge(
     const secp256k1_pubkey *T2, const unsigned char *context_id)
 {
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
-  unsigned char buf[33];
-  unsigned char h[32];
+  unsigned char buf[kMPT_PUBKEY_SIZE];
+  unsigned char h[kMPT_HALF_SHA_SIZE];
   size_t len;
   int ok = 0;
 
@@ -83,12 +83,12 @@ static int compute_compact_clawback_challenge(
 #define SER(pk_ptr)                                                            \
   do                                                                           \
   {                                                                            \
-    len = 33;                                                                  \
+    len = kMPT_PUBKEY_SIZE;                                                    \
     if (!secp256k1_ec_pubkey_serialize(ctx, buf, &len, pk_ptr,                 \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        len != 33)                                                             \
+        len != kMPT_PUBKEY_SIZE)                                               \
       goto cleanup;                                                            \
-    if (EVP_DigestUpdate(mdctx, buf, 33) != 1)                                 \
+    if (EVP_DigestUpdate(mdctx, buf, kMPT_PUBKEY_SIZE) != 1)                   \
       goto cleanup;                                                            \
   } while (0)
 
@@ -107,7 +107,7 @@ static int compute_compact_clawback_challenge(
 
   if (context_id)
   {
-    if (EVP_DigestUpdate(mdctx, context_id, 32) != 1)
+    if (EVP_DigestUpdate(mdctx, context_id, kMPT_HALF_SHA_SIZE) != 1)
       goto cleanup;
   }
 
@@ -151,10 +151,10 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
     unsigned char witness_buf[32];
     memcpy(witness_buf, sk_iss, 32);
 
-    unsigned char stmt_hash[32];
+    unsigned char stmt_hash[kMPT_HALF_SHA_SIZE];
     {
       EVP_MD_CTX *sh = EVP_MD_CTX_new();
-      unsigned char sbuf[33];
+      unsigned char sbuf[kMPT_PUBKEY_SIZE];
       size_t slen;
       if (!sh)
       {
@@ -170,16 +170,16 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
 #define SHASH(pk_ptr)                                                          \
   do                                                                           \
   {                                                                            \
-    slen = 33;                                                                 \
+    slen = kMPT_PUBKEY_SIZE;                                                   \
     if (!secp256k1_ec_pubkey_serialize(ctx, sbuf, &slen, pk_ptr,               \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        slen != 33)                                                            \
+        slen != kMPT_PUBKEY_SIZE)                                              \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
       goto cleanup;                                                            \
     }                                                                          \
-    if (EVP_DigestUpdate(sh, sbuf, 33) != 1)                                   \
+    if (EVP_DigestUpdate(sh, sbuf, kMPT_PUBKEY_SIZE) != 1)                     \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
@@ -197,7 +197,7 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
       }
       if (context_id)
       {
-        if (EVP_DigestUpdate(sh, context_id, 32) != 1)
+        if (EVP_DigestUpdate(sh, context_id, kMPT_HALF_SHA_SIZE) != 1)
         {
           EVP_MD_CTX_free(sh);
           OPENSSL_cleanse(witness_buf, sizeof(witness_buf));

--- a/src/proof_compact_convertback.c
+++ b/src/proof_compact_convertback.c
@@ -36,8 +36,8 @@ static int compute_compact_convertback_challenge(
     const secp256k1_pubkey *T_b, const unsigned char *context_id)
 {
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
-  unsigned char buf[33];
-  unsigned char h[32];
+  unsigned char buf[kMPT_PUBKEY_SIZE];
+  unsigned char h[kMPT_HALF_SHA_SIZE];
   size_t len;
   int ok = 0;
 
@@ -53,12 +53,12 @@ static int compute_compact_convertback_challenge(
 #define SER(pk_ptr)                                                            \
   do                                                                           \
   {                                                                            \
-    len = 33;                                                                  \
+    len = kMPT_PUBKEY_SIZE;                                                    \
     if (!secp256k1_ec_pubkey_serialize(ctx, buf, &len, pk_ptr,                 \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        len != 33)                                                             \
+        len != kMPT_PUBKEY_SIZE)                                               \
       goto cleanup;                                                            \
-    if (EVP_DigestUpdate(mdctx, buf, 33) != 1)                                 \
+    if (EVP_DigestUpdate(mdctx, buf, kMPT_PUBKEY_SIZE) != 1)                   \
       goto cleanup;                                                            \
   } while (0)
 
@@ -77,7 +77,7 @@ static int compute_compact_convertback_challenge(
 
   if (context_id)
   {
-    if (EVP_DigestUpdate(mdctx, context_id, 32) != 1)
+    if (EVP_DigestUpdate(mdctx, context_id, kMPT_HALF_SHA_SIZE) != 1)
       goto cleanup;
   }
 
@@ -135,10 +135,10 @@ int secp256k1_compact_convertback_prove(
     memcpy(witness_buf + 64, sk_A, 32);
 
     /* Hash public statement elements */
-    unsigned char stmt_hash[32];
+    unsigned char stmt_hash[kMPT_HALF_SHA_SIZE];
     {
       EVP_MD_CTX *sh = EVP_MD_CTX_new();
-      unsigned char sbuf[33];
+      unsigned char sbuf[kMPT_PUBKEY_SIZE];
       size_t slen;
       if (!sh)
       {
@@ -154,16 +154,16 @@ int secp256k1_compact_convertback_prove(
 #define SHASH(pk_ptr)                                                          \
   do                                                                           \
   {                                                                            \
-    slen = 33;                                                                 \
+    slen = kMPT_PUBKEY_SIZE;                                                   \
     if (!secp256k1_ec_pubkey_serialize(ctx, sbuf, &slen, pk_ptr,               \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        slen != 33)                                                            \
+        slen != kMPT_PUBKEY_SIZE)                                              \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
       goto cleanup;                                                            \
     }                                                                          \
-    if (EVP_DigestUpdate(sh, sbuf, 33) != 1)                                   \
+    if (EVP_DigestUpdate(sh, sbuf, kMPT_PUBKEY_SIZE) != 1)                     \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
@@ -176,7 +176,7 @@ int secp256k1_compact_convertback_prove(
       SHASH(PC_b);
       if (context_id)
       {
-        if (EVP_DigestUpdate(sh, context_id, 32) != 1)
+        if (EVP_DigestUpdate(sh, context_id, kMPT_HALF_SHA_SIZE) != 1)
         {
           EVP_MD_CTX_free(sh);
           OPENSSL_cleanse(witness_buf, sizeof(witness_buf));

--- a/src/proof_compact_standard.c
+++ b/src/proof_compact_standard.c
@@ -56,8 +56,8 @@ static int compute_compact_std_challenge(
     const unsigned char *context_id)
 {
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
-  unsigned char buf[33];
-  unsigned char h[32];
+  unsigned char buf[kMPT_PUBKEY_SIZE];
+  unsigned char h[kMPT_HALF_SHA_SIZE];
   size_t len;
   int ok = 0;
 
@@ -73,12 +73,12 @@ static int compute_compact_std_challenge(
 #define SER(pk_ptr)                                                            \
   do                                                                           \
   {                                                                            \
-    len = 33;                                                                  \
+    len = kMPT_PUBKEY_SIZE;                                                    \
     if (!secp256k1_ec_pubkey_serialize(ctx, buf, &len, pk_ptr,                 \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        len != 33)                                                             \
+        len != kMPT_PUBKEY_SIZE)                                               \
       goto cleanup;                                                            \
-    if (EVP_DigestUpdate(mdctx, buf, 33) != 1)                                 \
+    if (EVP_DigestUpdate(mdctx, buf, kMPT_PUBKEY_SIZE) != 1)                   \
       goto cleanup;                                                            \
   } while (0)
 
@@ -107,7 +107,7 @@ static int compute_compact_std_challenge(
 
   if (context_id)
   {
-    if (EVP_DigestUpdate(mdctx, context_id, 32) != 1)
+    if (EVP_DigestUpdate(mdctx, context_id, kMPT_HALF_SHA_SIZE) != 1)
       goto cleanup;
   }
 
@@ -188,10 +188,10 @@ int secp256k1_compact_standard_prove(
     memcpy(witness_buf + 128, r_b, 32);
 
     /* Hash all public statement elements into a 32-byte digest */
-    unsigned char stmt_hash[32];
+    unsigned char stmt_hash[kMPT_HALF_SHA_SIZE];
     {
       EVP_MD_CTX *sh = EVP_MD_CTX_new();
-      unsigned char sbuf[33];
+      unsigned char sbuf[kMPT_PUBKEY_SIZE];
       size_t slen;
       if (!sh)
       {
@@ -207,16 +207,16 @@ int secp256k1_compact_standard_prove(
 #define SHASH(pk_ptr)                                                          \
   do                                                                           \
   {                                                                            \
-    slen = 33;                                                                 \
+    slen = kMPT_PUBKEY_SIZE;                                                   \
     if (!secp256k1_ec_pubkey_serialize(ctx, sbuf, &slen, pk_ptr,               \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        slen != 33)                                                            \
+        slen != kMPT_PUBKEY_SIZE)                                              \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
       goto cleanup;                                                            \
     }                                                                          \
-    if (EVP_DigestUpdate(sh, sbuf, 33) != 1)                                   \
+    if (EVP_DigestUpdate(sh, sbuf, kMPT_PUBKEY_SIZE) != 1)                     \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
@@ -235,7 +235,7 @@ int secp256k1_compact_standard_prove(
       SHASH(B2);
       if (context_id)
       {
-        if (EVP_DigestUpdate(sh, context_id, 32) != 1)
+        if (EVP_DigestUpdate(sh, context_id, kMPT_HALF_SHA_SIZE) != 1)
         {
           EVP_MD_CTX_free(sh);
           OPENSSL_cleanse(witness_buf, sizeof(witness_buf));

--- a/src/proof_pok_sk.c
+++ b/src/proof_pok_sk.c
@@ -26,8 +26,8 @@ static int build_pok_challenge(const secp256k1_context *ctx,
                                const unsigned char *context_id)
 {
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
-  unsigned char buf[33];
-  unsigned char h[32];
+  unsigned char buf[kMPT_PUBKEY_SIZE];
+  unsigned char h[kMPT_HALF_SHA_SIZE];
   size_t len;
   int ok = 0;
 
@@ -42,12 +42,12 @@ static int build_pok_challenge(const secp256k1_context *ctx,
 #define SER(pk_ptr)                                                            \
   do                                                                           \
   {                                                                            \
-    len = 33;                                                                  \
+    len = kMPT_PUBKEY_SIZE;                                                    \
     if (!secp256k1_ec_pubkey_serialize(ctx, buf, &len, pk_ptr,                 \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        len != 33)                                                             \
+        len != kMPT_PUBKEY_SIZE)                                               \
       goto cleanup;                                                            \
-    if (EVP_DigestUpdate(mdctx, buf, 33) != 1)                                 \
+    if (EVP_DigestUpdate(mdctx, buf, kMPT_PUBKEY_SIZE) != 1)                   \
       goto cleanup;                                                            \
   } while (0)
 
@@ -58,7 +58,7 @@ static int build_pok_challenge(const secp256k1_context *ctx,
 
   if (context_id)
   {
-    if (EVP_DigestUpdate(mdctx, context_id, 32) != 1)
+    if (EVP_DigestUpdate(mdctx, context_id, kMPT_HALF_SHA_SIZE) != 1)
       goto cleanup;
   }
 
@@ -96,10 +96,10 @@ int secp256k1_mpt_pok_sk_prove(const secp256k1_context *ctx,
 
   /* 1. Deterministic nonce */
   {
-    unsigned char stmt_hash[32];
+    unsigned char stmt_hash[kMPT_HALF_SHA_SIZE];
     {
       EVP_MD_CTX *sh = EVP_MD_CTX_new();
-      unsigned char sbuf[33];
+      unsigned char sbuf[kMPT_PUBKEY_SIZE];
       size_t slen;
       if (!sh)
         goto cleanup;
@@ -108,22 +108,22 @@ int secp256k1_mpt_pok_sk_prove(const secp256k1_context *ctx,
         EVP_MD_CTX_free(sh);
         goto cleanup;
       }
-      slen = 33;
+      slen = kMPT_PUBKEY_SIZE;
       if (!secp256k1_ec_pubkey_serialize(ctx, sbuf, &slen, pk,
                                          SECP256K1_EC_COMPRESSED) ||
-          slen != 33)
+          slen != kMPT_PUBKEY_SIZE)
       {
         EVP_MD_CTX_free(sh);
         goto cleanup;
       }
-      if (EVP_DigestUpdate(sh, sbuf, 33) != 1)
+      if (EVP_DigestUpdate(sh, sbuf, kMPT_PUBKEY_SIZE) != 1)
       {
         EVP_MD_CTX_free(sh);
         goto cleanup;
       }
       if (context_id)
       {
-        if (EVP_DigestUpdate(sh, context_id, 32) != 1)
+        if (EVP_DigestUpdate(sh, context_id, kMPT_HALF_SHA_SIZE) != 1)
         {
           EVP_MD_CTX_free(sh);
           goto cleanup;


### PR DESCRIPTION
## Summary

Sweeps the obvious `32` (SHA-256 output / scalar) and `33` (compressed-pubkey serialization) magic numbers in transcript helpers and replaces them with the named constants from `mpt_protocol.h` (`kMPT_HALF_SHA_SIZE`, `kMPT_PUBKEY_SIZE`).

Touched:

- `include/secp256k1_mpt.h` — adds `#include "mpt_protocol.h"` so callers transitively see `kMPT_*`.
- `src/commitments.c` — NUMS hash buffer + serialized-pubkey parse buffer.
- `src/elgamal.c` — RAND_bytes / OPENSSL_cleanse on private keys, EVP md_len.
- `src/proof_pok_sk.c` — challenge transcript buffers + statement-hash buffers.
- `src/proof_compact_standard.c` — same for the standard sigma transcript.
- `src/proof_compact_clawback.c` — same for the clawback transcript (including the m·G amount-point helper).
- `src/proof_compact_convertback.c` — same for the convertback transcript.

## Out of scope

- **Scalar buffers** (e.g. `alpha[32]`, `e[32]`, `z_*[32]`, `t_*[32]`, `nonces[N*32]`, `witness_buf[N*32]`, `m_scalar[32]`, `b_scalar[32]`) and the positional `memcpy`s into `proof_out` / out of `proof`: these track the proof layout, not a protocol-level constant. Introducing `kMPT_SCALAR_SIZE` (32) and threading it through is a larger judgment call (every scalar offset becomes `i * kMPT_SCALAR_SIZE`), so deferred.
- `src/bulletproof_aggregated.c`: dense, performance-critical, and already uses local `enum` constants. Sweeping it is a separate exercise.

Closes part of #64. The remaining items above can be done in a follow-up if the auditor wants them.

## Test plan
- [x] `cmake --build build-debug` — clean, no warnings.
- [x] `ctest --output-on-failure` — 10/10 pass (elgamal, elgamal_verify, pok_sk, commitments, ipa, bulletproof_agg, mpt_utility, compact_standard, compact_clawback, compact_convertback).
- [x] `pre-commit run --all-files` — all hooks pass.