### PR TITLE
refactor: introduce kMPT_SCALAR_SIZE and sweep scalar buffers / cleanse / memcmp sites

### DIFF
--- a/include/mpt_protocol.h
+++ b/include/mpt_protocol.h
@@ -19,6 +19,10 @@ extern "C" {
 #define kMPT_PUBKEY_SIZE 33
 #define kMPT_PRIVKEY_SIZE 32
 #define kMPT_BLINDING_FACTOR_SIZE 32
+// secp256k1 scalar (challenge / response / nonce) size in bytes.
+// Numerically equal to kMPT_HALF_SHA_SIZE; use this name when the value is a
+// scalar in Z_q rather than a hash output.
+#define kMPT_SCALAR_SIZE 32
 
 // ElGamal & Pedersen primitive sizes in bytes
 #define kMPT_ELGAMAL_CIPHER_SIZE 33

--- a/include/secp256k1_mpt.h
+++ b/include/secp256k1_mpt.h
@@ -1,6 +1,7 @@
 #ifndef SECP256K1_MPT_H
 #define SECP256K1_MPT_H
 
+#include "mpt_protocol.h"
 #include <secp256k1.h>
 #include <stdint.h>
 

--- a/src/commitments.c
+++ b/src/commitments.c
@@ -55,8 +55,8 @@ int secp256k1_mpt_hash_to_point_nums(const secp256k1_context *ctx,
                                      const unsigned char *label,
                                      size_t label_len, uint32_t index)
 {
-  unsigned char hash[32];
-  unsigned char compressed[33];
+  unsigned char hash[kMPT_HALF_SHA_SIZE];
+  unsigned char compressed[kMPT_PUBKEY_SIZE];
   uint32_t ctr = 0;
 
   unsigned char idx_be[4] = {
@@ -115,9 +115,9 @@ int secp256k1_mpt_hash_to_point_nums(const secp256k1_context *ctx,
 
     compressed[0] =
         0x02; // Force even Y (standard convention for unique points)
-    memcpy(&compressed[1], hash, 32);
+    memcpy(&compressed[1], hash, kMPT_HALF_SHA_SIZE);
 
-    if (secp256k1_ec_pubkey_parse(ctx, out, compressed, 33) == 1)
+    if (secp256k1_ec_pubkey_parse(ctx, out, compressed, kMPT_PUBKEY_SIZE) == 1)
     {
       EVP_MD_CTX_free(mdctx);
       return 1;

--- a/src/commitments.c
+++ b/src/commitments.c
@@ -203,7 +203,7 @@ int secp256k1_mpt_pedersen_commit(const secp256k1_context *ctx,
   MPT_ARG_CHECK(rho != NULL);
 
   secp256k1_pubkey mG, rH, H;
-  unsigned char m_scalar[32] = {0};
+  unsigned char m_scalar[kMPT_SCALAR_SIZE] = {0};
   int ok = 0;
 
   /* 0. Input Check */
@@ -247,6 +247,6 @@ int secp256k1_mpt_pedersen_commit(const secp256k1_context *ctx,
 
 cleanup:
   /* Securely clear the amount scalar from stack */
-  OPENSSL_cleanse(m_scalar, 32);
+  OPENSSL_cleanse(m_scalar, kMPT_SCALAR_SIZE);
   return ok;
 }

--- a/src/elgamal.c
+++ b/src/elgamal.c
@@ -55,13 +55,13 @@ int secp256k1_elgamal_generate_keypair(const secp256k1_context *ctx,
 
   do
   {
-    if (RAND_bytes(privkey, 32) != 1)
+    if (RAND_bytes(privkey, kMPT_PRIVKEY_SIZE) != 1)
       return 0;
   } while (!secp256k1_ec_seckey_verify(ctx, privkey));
 
   if (!secp256k1_ec_pubkey_create(ctx, pubkey, privkey))
   {
-    OPENSSL_cleanse(privkey, 32); // Cleanup on failure
+    OPENSSL_cleanse(privkey, kMPT_PRIVKEY_SIZE); // Cleanup on failure
     return 0;
   }
   return 1;
@@ -423,7 +423,7 @@ int generate_canonical_encrypted_zero(
   memcpy(hash_input + 27, mpt_issuance_id, 24);
 
   /* Initial hash of the domain-tagged input. */
-  unsigned int md_len = 32;
+  unsigned int md_len = kMPT_HALF_SHA_SIZE;
   if (EVP_Digest(hash_input, 51, deterministic_scalar, &md_len, EVP_sha256(),
                  NULL) != 1)
     return 0;
@@ -436,8 +436,8 @@ int generate_canonical_encrypted_zero(
    * yield a non-standard construction without any security benefit. */
   while (!secp256k1_ec_seckey_verify(ctx, deterministic_scalar))
   {
-    if (EVP_Digest(deterministic_scalar, 32, deterministic_scalar, &md_len,
-                   EVP_sha256(), NULL) != 1)
+    if (EVP_Digest(deterministic_scalar, kMPT_HALF_SHA_SIZE,
+                   deterministic_scalar, &md_len, EVP_sha256(), NULL) != 1)
       return 0;
   }
 

--- a/src/elgamal.c
+++ b/src/elgamal.c
@@ -142,13 +142,13 @@ static int secp256k1_solve_dlp_small_range_fixed(
     return 1;
   }
 
-  unsigned char one[32] = {0};
-  one[31] = 1;
+  unsigned char one[kMPT_SCALAR_SIZE] = {0};
+  one[kMPT_SCALAR_SIZE - 1] = 1;
 
   secp256k1_pubkey G_point;
   if (!secp256k1_ec_pubkey_create(ctx, &G_point, one))
   {
-    OPENSSL_cleanse(one, 32);
+    OPENSSL_cleanse(one, kMPT_SCALAR_SIZE);
     return 0;
   }
 
@@ -219,7 +219,7 @@ static int secp256k1_solve_dlp_small_range_fixed(
   }
 
   OPENSSL_cleanse(current_M_ser, 33);
-  OPENSSL_cleanse(one, 32);
+  OPENSSL_cleanse(one, kMPT_SCALAR_SIZE);
 
   if (global_ser_error != 0)
   {
@@ -412,7 +412,7 @@ int generate_canonical_encrypted_zero(
   MPT_ARG_CHECK(account_id != NULL);
   MPT_ARG_CHECK(mpt_issuance_id != NULL);
 
-  unsigned char deterministic_scalar[32];
+  unsigned char deterministic_scalar[kMPT_SCALAR_SIZE];
   unsigned char hash_input[51]; // 7 ("EncZero") + 20 + 24
   const char *domain = "EncZero";
   int ret;
@@ -444,7 +444,7 @@ int generate_canonical_encrypted_zero(
   ret = secp256k1_elgamal_encrypt(ctx, enc_zero_c1, enc_zero_c2, pubkey, 0,
                                   deterministic_scalar);
 
-  OPENSSL_cleanse(deterministic_scalar, 32); // Secure cleanup
+  OPENSSL_cleanse(deterministic_scalar, kMPT_SCALAR_SIZE); // Secure cleanup
   return ret;
 }
 

--- a/src/proof_compact_clawback.c
+++ b/src/proof_compact_clawback.c
@@ -138,8 +138,8 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
   MPT_ARG_CHECK(C1 != NULL);
   MPT_ARG_CHECK(C2 != NULL);
 
-  unsigned char t_sk[32];
-  unsigned char e[32], z_sk[32];
+  unsigned char t_sk[kMPT_SCALAR_SIZE];
+  unsigned char e[kMPT_SCALAR_SIZE], z_sk[kMPT_SCALAR_SIZE];
   secp256k1_pubkey T1, T2;
   int ok = 0;
 
@@ -148,8 +148,8 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
 
   /* 1. Deterministic nonce */
   {
-    unsigned char witness_buf[32];
-    memcpy(witness_buf, sk_iss, 32);
+    unsigned char witness_buf[kMPT_SCALAR_SIZE];
+    memcpy(witness_buf, sk_iss, kMPT_SCALAR_SIZE);
 
     unsigned char stmt_hash[kMPT_HALF_SHA_SIZE];
     {
@@ -209,7 +209,7 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
 #undef SHASH
     }
 
-    unsigned char nonces[32];
+    unsigned char nonces[kMPT_SCALAR_SIZE];
     if (!generate_deterministic_nonces(
             ctx, nonces, 1, witness_buf, sizeof(witness_buf), stmt_hash,
             DOMAIN_COMPACT_CLAWBACK, strlen(DOMAIN_COMPACT_CLAWBACK)))
@@ -217,7 +217,7 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));
       goto cleanup;
     }
-    memcpy(t_sk, nonces, 32);
+    memcpy(t_sk, nonces, kMPT_SCALAR_SIZE);
     OPENSSL_cleanse(witness_buf, sizeof(witness_buf));
     OPENSSL_cleanse(nonces, sizeof(nonces));
   }
@@ -239,15 +239,15 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
   compute_sigma_response(z_sk, t_sk, e, sk_iss);
 
   /* 5. Serialize: e || z_sk */
-  memcpy(proof_out, e, 32);
-  memcpy(proof_out + 32, z_sk, 32);
+  memcpy(proof_out, e, kMPT_SCALAR_SIZE);
+  memcpy(proof_out + 32, z_sk, kMPT_SCALAR_SIZE);
 
   ok = 1;
 
 cleanup:
-  OPENSSL_cleanse(t_sk, 32);
-  OPENSSL_cleanse(e, 32);
-  OPENSSL_cleanse(z_sk, 32);
+  OPENSSL_cleanse(t_sk, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(e, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(z_sk, kMPT_SCALAR_SIZE);
   return ok;
 }
 
@@ -264,12 +264,13 @@ int secp256k1_compact_clawback_verify(
   MPT_ARG_CHECK(C1 != NULL);
   MPT_ARG_CHECK(C2 != NULL);
 
-  unsigned char e[32], z_sk[32], e_prime[32], neg_e[32];
+  unsigned char e[kMPT_SCALAR_SIZE], z_sk[kMPT_SCALAR_SIZE];
+  unsigned char e_prime[kMPT_SCALAR_SIZE], neg_e[kMPT_SCALAR_SIZE];
   secp256k1_pubkey T1, T2;
 
   /* 1. Deserialize: e || z_sk */
-  memcpy(e, proof, 32);
-  memcpy(z_sk, proof + 32, 32);
+  memcpy(e, proof, kMPT_SCALAR_SIZE);
+  memcpy(z_sk, proof + 32, kMPT_SCALAR_SIZE);
 
   if (!secp256k1_ec_seckey_verify(ctx, e))
     return 0;
@@ -307,9 +308,9 @@ int secp256k1_compact_clawback_verify(
       secp256k1_pubkey mG;
       if (!compute_amount_point(ctx, &mG, amount))
         return 0;
-      unsigned char neg_one[32];
-      unsigned char one[32] = {0};
-      one[31] = 1;
+      unsigned char neg_one[kMPT_SCALAR_SIZE];
+      unsigned char one[kMPT_SCALAR_SIZE] = {0};
+      one[kMPT_SCALAR_SIZE - 1] = 1;
       secp256k1_mpt_scalar_negate(neg_one, one);
       secp256k1_pubkey neg_mG = mG;
       if (!secp256k1_ec_pubkey_tweak_mul(ctx, &neg_mG, neg_one))
@@ -336,5 +337,5 @@ int secp256k1_compact_clawback_verify(
     return 0;
 
   /* 4. Accept iff e' == e */
-  return CRYPTO_memcmp(e, e_prime, 32) == 0;
+  return CRYPTO_memcmp(e, e_prime, kMPT_SCALAR_SIZE) == 0;
 }

--- a/src/proof_compact_clawback.c
+++ b/src/proof_compact_clawback.c
@@ -40,23 +40,23 @@ static const char DOMAIN_COMPACT_CLAWBACK[] = "CMPT_CLAWBACK_SIGMA";
 static int digest_update_amount_point(const secp256k1_context *ctx,
                                       EVP_MD_CTX *mdctx, uint64_t amount)
 {
-  unsigned char buf[33];
+  unsigned char buf[kMPT_PUBKEY_SIZE];
   if (amount == 0)
   {
-    memset(buf, 0, 33);
+    memset(buf, 0, kMPT_PUBKEY_SIZE);
   }
   else
   {
     secp256k1_pubkey mG;
-    size_t len = 33;
+    size_t len = kMPT_PUBKEY_SIZE;
     if (!compute_amount_point(ctx, &mG, amount))
       return 0;
     if (!secp256k1_ec_pubkey_serialize(ctx, buf, &len, &mG,
                                        SECP256K1_EC_COMPRESSED) ||
-        len != 33)
+        len != kMPT_PUBKEY_SIZE)
       return 0;
   }
-  return EVP_DigestUpdate(mdctx, buf, 33);
+  return EVP_DigestUpdate(mdctx, buf, kMPT_PUBKEY_SIZE);
 }
 
 static int compute_compact_clawback_challenge(
@@ -66,8 +66,8 @@ static int compute_compact_clawback_challenge(
     const secp256k1_pubkey *T2, const unsigned char *context_id)
 {
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
-  unsigned char buf[33];
-  unsigned char h[32];
+  unsigned char buf[kMPT_PUBKEY_SIZE];
+  unsigned char h[kMPT_HALF_SHA_SIZE];
   size_t len;
   int ok = 0;
 
@@ -83,12 +83,12 @@ static int compute_compact_clawback_challenge(
 #define SER(pk_ptr)                                                            \
   do                                                                           \
   {                                                                            \
-    len = 33;                                                                  \
+    len = kMPT_PUBKEY_SIZE;                                                    \
     if (!secp256k1_ec_pubkey_serialize(ctx, buf, &len, pk_ptr,                 \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        len != 33)                                                             \
+        len != kMPT_PUBKEY_SIZE)                                               \
       goto cleanup;                                                            \
-    if (EVP_DigestUpdate(mdctx, buf, 33) != 1)                                 \
+    if (EVP_DigestUpdate(mdctx, buf, kMPT_PUBKEY_SIZE) != 1)                   \
       goto cleanup;                                                            \
   } while (0)
 
@@ -107,7 +107,7 @@ static int compute_compact_clawback_challenge(
 
   if (context_id)
   {
-    if (EVP_DigestUpdate(mdctx, context_id, 32) != 1)
+    if (EVP_DigestUpdate(mdctx, context_id, kMPT_HALF_SHA_SIZE) != 1)
       goto cleanup;
   }
 
@@ -151,10 +151,10 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
     unsigned char witness_buf[32];
     memcpy(witness_buf, sk_iss, 32);
 
-    unsigned char stmt_hash[32];
+    unsigned char stmt_hash[kMPT_HALF_SHA_SIZE];
     {
       EVP_MD_CTX *sh = EVP_MD_CTX_new();
-      unsigned char sbuf[33];
+      unsigned char sbuf[kMPT_PUBKEY_SIZE];
       size_t slen;
       if (!sh)
       {
@@ -170,16 +170,16 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
 #define SHASH(pk_ptr)                                                          \
   do                                                                           \
   {                                                                            \
-    slen = 33;                                                                 \
+    slen = kMPT_PUBKEY_SIZE;                                                   \
     if (!secp256k1_ec_pubkey_serialize(ctx, sbuf, &slen, pk_ptr,               \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        slen != 33)                                                            \
+        slen != kMPT_PUBKEY_SIZE)                                              \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
       goto cleanup;                                                            \
     }                                                                          \
-    if (EVP_DigestUpdate(sh, sbuf, 33) != 1)                                   \
+    if (EVP_DigestUpdate(sh, sbuf, kMPT_PUBKEY_SIZE) != 1)                     \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
@@ -197,7 +197,7 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
       }
       if (context_id)
       {
-        if (EVP_DigestUpdate(sh, context_id, 32) != 1)
+        if (EVP_DigestUpdate(sh, context_id, kMPT_HALF_SHA_SIZE) != 1)
         {
           EVP_MD_CTX_free(sh);
           OPENSSL_cleanse(witness_buf, sizeof(witness_buf));

--- a/src/proof_compact_convertback.c
+++ b/src/proof_compact_convertback.c
@@ -109,9 +109,11 @@ int secp256k1_compact_convertback_prove(
   MPT_ARG_CHECK(B2 != NULL);
   MPT_ARG_CHECK(PC_b != NULL);
 
-  unsigned char t_b[32], t_sk[32], t_rho[32];
-  unsigned char b_scalar[32];
-  unsigned char e[32], z_b[32], z_sk[32], z_rho[32];
+  unsigned char t_b[kMPT_SCALAR_SIZE], t_sk[kMPT_SCALAR_SIZE];
+  unsigned char t_rho[kMPT_SCALAR_SIZE];
+  unsigned char b_scalar[kMPT_SCALAR_SIZE];
+  unsigned char e[kMPT_SCALAR_SIZE], z_b[kMPT_SCALAR_SIZE];
+  unsigned char z_sk[kMPT_SCALAR_SIZE], z_rho[kMPT_SCALAR_SIZE];
   secp256k1_pubkey T_sk1, T_sk2, T_b;
   secp256k1_pubkey H;
   int ok = 0;
@@ -129,10 +131,10 @@ int secp256k1_compact_convertback_prove(
   /* 1. Deterministic nonces (witness || statement || fresh entropy) */
   {
     /* Witness in canonical order: b, rho, sk_A */
-    unsigned char witness_buf[3 * 32];
-    memcpy(witness_buf, b_scalar, 32);
-    memcpy(witness_buf + 32, rho, 32);
-    memcpy(witness_buf + 64, sk_A, 32);
+    unsigned char witness_buf[3 * kMPT_SCALAR_SIZE];
+    memcpy(witness_buf, b_scalar, kMPT_SCALAR_SIZE);
+    memcpy(witness_buf + 32, rho, kMPT_SCALAR_SIZE);
+    memcpy(witness_buf + 64, sk_A, kMPT_SCALAR_SIZE);
 
     /* Hash public statement elements */
     unsigned char stmt_hash[kMPT_HALF_SHA_SIZE];
@@ -188,7 +190,7 @@ int secp256k1_compact_convertback_prove(
 #undef SHASH
     }
 
-    unsigned char nonces[3 * 32];
+    unsigned char nonces[3 * kMPT_SCALAR_SIZE];
     if (!generate_deterministic_nonces(
             ctx, nonces, 3, witness_buf, sizeof(witness_buf), stmt_hash,
             DOMAIN_COMPACT_CONVERTBACK, strlen(DOMAIN_COMPACT_CONVERTBACK)))
@@ -196,9 +198,9 @@ int secp256k1_compact_convertback_prove(
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));
       goto cleanup;
     }
-    memcpy(t_b, nonces, 32);
-    memcpy(t_sk, nonces + 32, 32);
-    memcpy(t_rho, nonces + 64, 32);
+    memcpy(t_b, nonces, kMPT_SCALAR_SIZE);
+    memcpy(t_sk, nonces + 32, kMPT_SCALAR_SIZE);
+    memcpy(t_rho, nonces + 64, kMPT_SCALAR_SIZE);
     OPENSSL_cleanse(witness_buf, sizeof(witness_buf));
     OPENSSL_cleanse(nonces, sizeof(nonces));
   }
@@ -246,22 +248,22 @@ int secp256k1_compact_convertback_prove(
   compute_sigma_response(z_rho, t_rho, e, rho);
 
   /* 5. Serialize: e || z_b || z_rho || z_sk */
-  memcpy(proof_out, e, 32);
-  memcpy(proof_out + 32, z_b, 32);
-  memcpy(proof_out + 64, z_rho, 32);
-  memcpy(proof_out + 96, z_sk, 32);
+  memcpy(proof_out, e, kMPT_SCALAR_SIZE);
+  memcpy(proof_out + 32, z_b, kMPT_SCALAR_SIZE);
+  memcpy(proof_out + 64, z_rho, kMPT_SCALAR_SIZE);
+  memcpy(proof_out + 96, z_sk, kMPT_SCALAR_SIZE);
 
   ok = 1;
 
 cleanup:
-  OPENSSL_cleanse(t_b, 32);
-  OPENSSL_cleanse(t_sk, 32);
-  OPENSSL_cleanse(t_rho, 32);
-  OPENSSL_cleanse(b_scalar, 32);
-  OPENSSL_cleanse(e, 32);
-  OPENSSL_cleanse(z_b, 32);
-  OPENSSL_cleanse(z_sk, 32);
-  OPENSSL_cleanse(z_rho, 32);
+  OPENSSL_cleanse(t_b, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(t_sk, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(t_rho, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(b_scalar, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(e, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(z_b, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(z_sk, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(z_rho, kMPT_SCALAR_SIZE);
   return ok;
 }
 
@@ -282,16 +284,17 @@ int secp256k1_compact_convertback_verify(const secp256k1_context *ctx,
   MPT_ARG_CHECK(B2 != NULL);
   MPT_ARG_CHECK(PC_b != NULL);
 
-  unsigned char e[32], z_b[32], z_sk[32], z_rho[32];
-  unsigned char e_prime[32], neg_e[32];
+  unsigned char e[kMPT_SCALAR_SIZE], z_b[kMPT_SCALAR_SIZE];
+  unsigned char z_sk[kMPT_SCALAR_SIZE], z_rho[kMPT_SCALAR_SIZE];
+  unsigned char e_prime[kMPT_SCALAR_SIZE], neg_e[kMPT_SCALAR_SIZE];
   secp256k1_pubkey T_sk1, T_sk2, T_b;
   secp256k1_pubkey H;
 
   /* 1. Deserialize: e || z_b || z_rho || z_sk */
-  memcpy(e, proof, 32);
-  memcpy(z_b, proof + 32, 32);
-  memcpy(z_rho, proof + 64, 32);
-  memcpy(z_sk, proof + 96, 32);
+  memcpy(e, proof, kMPT_SCALAR_SIZE);
+  memcpy(z_b, proof + 32, kMPT_SCALAR_SIZE);
+  memcpy(z_rho, proof + 64, kMPT_SCALAR_SIZE);
+  memcpy(z_sk, proof + 96, kMPT_SCALAR_SIZE);
 
   if (!secp256k1_ec_seckey_verify(ctx, e))
     return 0;
@@ -360,5 +363,5 @@ int secp256k1_compact_convertback_verify(const secp256k1_context *ctx,
     return 0;
 
   /* 4. Accept iff e' == e */
-  return CRYPTO_memcmp(e, e_prime, 32) == 0;
+  return CRYPTO_memcmp(e, e_prime, kMPT_SCALAR_SIZE) == 0;
 }

--- a/src/proof_compact_convertback.c
+++ b/src/proof_compact_convertback.c
@@ -36,8 +36,8 @@ static int compute_compact_convertback_challenge(
     const secp256k1_pubkey *T_b, const unsigned char *context_id)
 {
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
-  unsigned char buf[33];
-  unsigned char h[32];
+  unsigned char buf[kMPT_PUBKEY_SIZE];
+  unsigned char h[kMPT_HALF_SHA_SIZE];
   size_t len;
   int ok = 0;
 
@@ -53,12 +53,12 @@ static int compute_compact_convertback_challenge(
 #define SER(pk_ptr)                                                            \
   do                                                                           \
   {                                                                            \
-    len = 33;                                                                  \
+    len = kMPT_PUBKEY_SIZE;                                                    \
     if (!secp256k1_ec_pubkey_serialize(ctx, buf, &len, pk_ptr,                 \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        len != 33)                                                             \
+        len != kMPT_PUBKEY_SIZE)                                               \
       goto cleanup;                                                            \
-    if (EVP_DigestUpdate(mdctx, buf, 33) != 1)                                 \
+    if (EVP_DigestUpdate(mdctx, buf, kMPT_PUBKEY_SIZE) != 1)                   \
       goto cleanup;                                                            \
   } while (0)
 
@@ -77,7 +77,7 @@ static int compute_compact_convertback_challenge(
 
   if (context_id)
   {
-    if (EVP_DigestUpdate(mdctx, context_id, 32) != 1)
+    if (EVP_DigestUpdate(mdctx, context_id, kMPT_HALF_SHA_SIZE) != 1)
       goto cleanup;
   }
 
@@ -135,10 +135,10 @@ int secp256k1_compact_convertback_prove(
     memcpy(witness_buf + 64, sk_A, 32);
 
     /* Hash public statement elements */
-    unsigned char stmt_hash[32];
+    unsigned char stmt_hash[kMPT_HALF_SHA_SIZE];
     {
       EVP_MD_CTX *sh = EVP_MD_CTX_new();
-      unsigned char sbuf[33];
+      unsigned char sbuf[kMPT_PUBKEY_SIZE];
       size_t slen;
       if (!sh)
       {
@@ -154,16 +154,16 @@ int secp256k1_compact_convertback_prove(
 #define SHASH(pk_ptr)                                                          \
   do                                                                           \
   {                                                                            \
-    slen = 33;                                                                 \
+    slen = kMPT_PUBKEY_SIZE;                                                   \
     if (!secp256k1_ec_pubkey_serialize(ctx, sbuf, &slen, pk_ptr,               \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        slen != 33)                                                            \
+        slen != kMPT_PUBKEY_SIZE)                                              \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
       goto cleanup;                                                            \
     }                                                                          \
-    if (EVP_DigestUpdate(sh, sbuf, 33) != 1)                                   \
+    if (EVP_DigestUpdate(sh, sbuf, kMPT_PUBKEY_SIZE) != 1)                     \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
@@ -176,7 +176,7 @@ int secp256k1_compact_convertback_prove(
       SHASH(PC_b);
       if (context_id)
       {
-        if (EVP_DigestUpdate(sh, context_id, 32) != 1)
+        if (EVP_DigestUpdate(sh, context_id, kMPT_HALF_SHA_SIZE) != 1)
         {
           EVP_MD_CTX_free(sh);
           OPENSSL_cleanse(witness_buf, sizeof(witness_buf));

--- a/src/proof_compact_standard.c
+++ b/src/proof_compact_standard.c
@@ -150,9 +150,13 @@ int secp256k1_compact_standard_prove(
   MPT_ARG_CHECK(B2 != NULL);
 
   /* Nonces: alpha(r), beta(m), gamma(sk_A), delta(r_b), epsilon(b) */
-  unsigned char alpha[32], beta[32], gamma[32], delta[32], epsilon[32];
-  unsigned char m_scalar[32], b_scalar[32];
-  unsigned char e[32], z_r[32], z_m[32], z_sk[32], z_rb[32], z_b[32];
+  unsigned char alpha[kMPT_SCALAR_SIZE], beta[kMPT_SCALAR_SIZE];
+  unsigned char gamma[kMPT_SCALAR_SIZE], delta[kMPT_SCALAR_SIZE];
+  unsigned char epsilon[kMPT_SCALAR_SIZE];
+  unsigned char m_scalar[kMPT_SCALAR_SIZE], b_scalar[kMPT_SCALAR_SIZE];
+  unsigned char e[kMPT_SCALAR_SIZE], z_r[kMPT_SCALAR_SIZE];
+  unsigned char z_m[kMPT_SCALAR_SIZE], z_sk[kMPT_SCALAR_SIZE];
+  unsigned char z_rb[kMPT_SCALAR_SIZE], z_b[kMPT_SCALAR_SIZE];
   secp256k1_pubkey T1, T_PCm, K1, T_PCb, K2;
   secp256k1_pubkey *T2_vec = NULL;
   secp256k1_pubkey H;
@@ -180,12 +184,12 @@ int secp256k1_compact_standard_prove(
    *    Binds nonces to both witness and public statement.              */
   {
     /* Witness in canonical order: sk_A, r, m, b, rho */
-    unsigned char witness_buf[5 * 32];
-    memcpy(witness_buf, sk_A, 32);
-    memcpy(witness_buf + 32, r_shared, 32);
-    memcpy(witness_buf + 64, m_scalar, 32);
-    memcpy(witness_buf + 96, b_scalar, 32);
-    memcpy(witness_buf + 128, r_b, 32);
+    unsigned char witness_buf[5 * kMPT_SCALAR_SIZE];
+    memcpy(witness_buf, sk_A, kMPT_SCALAR_SIZE);
+    memcpy(witness_buf + 32, r_shared, kMPT_SCALAR_SIZE);
+    memcpy(witness_buf + 64, m_scalar, kMPT_SCALAR_SIZE);
+    memcpy(witness_buf + 96, b_scalar, kMPT_SCALAR_SIZE);
+    memcpy(witness_buf + 128, r_b, kMPT_SCALAR_SIZE);
 
     /* Hash all public statement elements into a 32-byte digest */
     unsigned char stmt_hash[kMPT_HALF_SHA_SIZE];
@@ -247,7 +251,7 @@ int secp256k1_compact_standard_prove(
 #undef SHASH
     }
 
-    unsigned char nonces[5 * 32];
+    unsigned char nonces[5 * kMPT_SCALAR_SIZE];
     if (!generate_deterministic_nonces(
             ctx, nonces, 5, witness_buf, sizeof(witness_buf), stmt_hash,
             DOMAIN_COMPACT_STANDARD, strlen(DOMAIN_COMPACT_STANDARD)))
@@ -255,11 +259,11 @@ int secp256k1_compact_standard_prove(
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));
       goto cleanup;
     }
-    memcpy(alpha, nonces, 32);
-    memcpy(beta, nonces + 32, 32);
-    memcpy(gamma, nonces + 64, 32);
-    memcpy(delta, nonces + 96, 32);
-    memcpy(epsilon, nonces + 128, 32);
+    memcpy(alpha, nonces, kMPT_SCALAR_SIZE);
+    memcpy(beta, nonces + 32, kMPT_SCALAR_SIZE);
+    memcpy(gamma, nonces + 64, kMPT_SCALAR_SIZE);
+    memcpy(delta, nonces + 96, kMPT_SCALAR_SIZE);
+    memcpy(epsilon, nonces + 128, kMPT_SCALAR_SIZE);
     OPENSSL_cleanse(witness_buf, sizeof(witness_buf));
     OPENSSL_cleanse(nonces, sizeof(nonces));
   }
@@ -349,29 +353,29 @@ int secp256k1_compact_standard_prove(
   compute_sigma_response(z_b, epsilon, e, b_scalar);
 
   /* 5. Serialize compact proof: e || z_m || z_r || z_b || z_rb || z_sk */
-  memcpy(proof_out, e, 32);
-  memcpy(proof_out + 32, z_m, 32);
-  memcpy(proof_out + 64, z_r, 32);
-  memcpy(proof_out + 96, z_b, 32);
-  memcpy(proof_out + 128, z_rb, 32);
-  memcpy(proof_out + 160, z_sk, 32);
+  memcpy(proof_out, e, kMPT_SCALAR_SIZE);
+  memcpy(proof_out + 32, z_m, kMPT_SCALAR_SIZE);
+  memcpy(proof_out + 64, z_r, kMPT_SCALAR_SIZE);
+  memcpy(proof_out + 96, z_b, kMPT_SCALAR_SIZE);
+  memcpy(proof_out + 128, z_rb, kMPT_SCALAR_SIZE);
+  memcpy(proof_out + 160, z_sk, kMPT_SCALAR_SIZE);
 
   ok = 1;
 
 cleanup:
-  OPENSSL_cleanse(alpha, 32);
-  OPENSSL_cleanse(beta, 32);
-  OPENSSL_cleanse(gamma, 32);
-  OPENSSL_cleanse(delta, 32);
-  OPENSSL_cleanse(epsilon, 32);
-  OPENSSL_cleanse(m_scalar, 32);
-  OPENSSL_cleanse(b_scalar, 32);
-  OPENSSL_cleanse(e, 32);
-  OPENSSL_cleanse(z_r, 32);
-  OPENSSL_cleanse(z_m, 32);
-  OPENSSL_cleanse(z_sk, 32);
-  OPENSSL_cleanse(z_rb, 32);
-  OPENSSL_cleanse(z_b, 32);
+  OPENSSL_cleanse(alpha, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(beta, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(gamma, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(delta, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(epsilon, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(m_scalar, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(b_scalar, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(e, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(z_r, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(z_m, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(z_sk, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(z_rb, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(z_b, kMPT_SCALAR_SIZE);
   free(T2_vec);
   return ok;
 }
@@ -400,20 +404,22 @@ int secp256k1_compact_standard_verify(
   MPT_ARG_CHECK(B1 != NULL);
   MPT_ARG_CHECK(B2 != NULL);
 
-  unsigned char e[32], z_r[32], z_m[32], z_sk[32], z_rb[32], z_b[32];
-  unsigned char e_prime[32], neg_e[32];
+  unsigned char e[kMPT_SCALAR_SIZE], z_r[kMPT_SCALAR_SIZE];
+  unsigned char z_m[kMPT_SCALAR_SIZE], z_sk[kMPT_SCALAR_SIZE];
+  unsigned char z_rb[kMPT_SCALAR_SIZE], z_b[kMPT_SCALAR_SIZE];
+  unsigned char e_prime[kMPT_SCALAR_SIZE], neg_e[kMPT_SCALAR_SIZE];
   secp256k1_pubkey T1, T_PCm, K1, T_PCb, K2;
   secp256k1_pubkey *T2_vec = NULL;
   secp256k1_pubkey H;
   int ok = 0;
 
   /* 1. Deserialize: e || z_m || z_r || z_b || z_rb || z_sk */
-  memcpy(e, proof, 32);
-  memcpy(z_m, proof + 32, 32);
-  memcpy(z_r, proof + 64, 32);
-  memcpy(z_b, proof + 96, 32);
-  memcpy(z_rb, proof + 128, 32);
-  memcpy(z_sk, proof + 160, 32);
+  memcpy(e, proof, kMPT_SCALAR_SIZE);
+  memcpy(z_m, proof + 32, kMPT_SCALAR_SIZE);
+  memcpy(z_r, proof + 64, kMPT_SCALAR_SIZE);
+  memcpy(z_b, proof + 96, kMPT_SCALAR_SIZE);
+  memcpy(z_rb, proof + 128, kMPT_SCALAR_SIZE);
+  memcpy(z_sk, proof + 160, kMPT_SCALAR_SIZE);
 
   /* secp256k1_ec_seckey_verify rejects zero scalars (returns 0 for s=0),
    * causing a negligible (~2^{-256}) deviation from strict completeness.
@@ -545,11 +551,11 @@ int secp256k1_compact_standard_verify(
     goto cleanup;
 
   /* 4. Accept iff e' == e (constant-time comparison) */
-  if (CRYPTO_memcmp(e, e_prime, 32) == 0)
+  if (CRYPTO_memcmp(e, e_prime, kMPT_SCALAR_SIZE) == 0)
     ok = 1;
 
 cleanup:
-  OPENSSL_cleanse(neg_e, 32);
+  OPENSSL_cleanse(neg_e, kMPT_SCALAR_SIZE);
   /* z_*, e, e_prime are public proof values — intentionally not cleansed */
   free(T2_vec);
   return ok;

--- a/src/proof_compact_standard.c
+++ b/src/proof_compact_standard.c
@@ -56,8 +56,8 @@ static int compute_compact_std_challenge(
     const unsigned char *context_id)
 {
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
-  unsigned char buf[33];
-  unsigned char h[32];
+  unsigned char buf[kMPT_PUBKEY_SIZE];
+  unsigned char h[kMPT_HALF_SHA_SIZE];
   size_t len;
   int ok = 0;
 
@@ -73,12 +73,12 @@ static int compute_compact_std_challenge(
 #define SER(pk_ptr)                                                            \
   do                                                                           \
   {                                                                            \
-    len = 33;                                                                  \
+    len = kMPT_PUBKEY_SIZE;                                                    \
     if (!secp256k1_ec_pubkey_serialize(ctx, buf, &len, pk_ptr,                 \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        len != 33)                                                             \
+        len != kMPT_PUBKEY_SIZE)                                               \
       goto cleanup;                                                            \
-    if (EVP_DigestUpdate(mdctx, buf, 33) != 1)                                 \
+    if (EVP_DigestUpdate(mdctx, buf, kMPT_PUBKEY_SIZE) != 1)                   \
       goto cleanup;                                                            \
   } while (0)
 
@@ -107,7 +107,7 @@ static int compute_compact_std_challenge(
 
   if (context_id)
   {
-    if (EVP_DigestUpdate(mdctx, context_id, 32) != 1)
+    if (EVP_DigestUpdate(mdctx, context_id, kMPT_HALF_SHA_SIZE) != 1)
       goto cleanup;
   }
 
@@ -188,10 +188,10 @@ int secp256k1_compact_standard_prove(
     memcpy(witness_buf + 128, r_b, 32);
 
     /* Hash all public statement elements into a 32-byte digest */
-    unsigned char stmt_hash[32];
+    unsigned char stmt_hash[kMPT_HALF_SHA_SIZE];
     {
       EVP_MD_CTX *sh = EVP_MD_CTX_new();
-      unsigned char sbuf[33];
+      unsigned char sbuf[kMPT_PUBKEY_SIZE];
       size_t slen;
       if (!sh)
       {
@@ -207,16 +207,16 @@ int secp256k1_compact_standard_prove(
 #define SHASH(pk_ptr)                                                          \
   do                                                                           \
   {                                                                            \
-    slen = 33;                                                                 \
+    slen = kMPT_PUBKEY_SIZE;                                                   \
     if (!secp256k1_ec_pubkey_serialize(ctx, sbuf, &slen, pk_ptr,               \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        slen != 33)                                                            \
+        slen != kMPT_PUBKEY_SIZE)                                              \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
       goto cleanup;                                                            \
     }                                                                          \
-    if (EVP_DigestUpdate(sh, sbuf, 33) != 1)                                   \
+    if (EVP_DigestUpdate(sh, sbuf, kMPT_PUBKEY_SIZE) != 1)                     \
     {                                                                          \
       EVP_MD_CTX_free(sh);                                                     \
       OPENSSL_cleanse(witness_buf, sizeof(witness_buf));                       \
@@ -235,7 +235,7 @@ int secp256k1_compact_standard_prove(
       SHASH(B2);
       if (context_id)
       {
-        if (EVP_DigestUpdate(sh, context_id, 32) != 1)
+        if (EVP_DigestUpdate(sh, context_id, kMPT_HALF_SHA_SIZE) != 1)
         {
           EVP_MD_CTX_free(sh);
           OPENSSL_cleanse(witness_buf, sizeof(witness_buf));

--- a/src/proof_pok_sk.c
+++ b/src/proof_pok_sk.c
@@ -86,8 +86,8 @@ int secp256k1_mpt_pok_sk_prove(const secp256k1_context *ctx,
   MPT_ARG_CHECK(sk != NULL);
   /* context_id is optional */
 
-  unsigned char k[32];
-  unsigned char e[32], s[32];
+  unsigned char k[kMPT_SCALAR_SIZE];
+  unsigned char e[kMPT_SCALAR_SIZE], s[kMPT_SCALAR_SIZE];
   secp256k1_pubkey T;
   int ok = 0;
 
@@ -133,11 +133,12 @@ int secp256k1_mpt_pok_sk_prove(const secp256k1_context *ctx,
       EVP_MD_CTX_free(sh);
     }
 
-    unsigned char nonces[32];
-    if (!generate_deterministic_nonces(ctx, nonces, 1, sk, 32, stmt_hash,
-                                       DOMAIN_POK_SK, strlen(DOMAIN_POK_SK)))
+    unsigned char nonces[kMPT_SCALAR_SIZE];
+    if (!generate_deterministic_nonces(ctx, nonces, 1, sk, kMPT_SCALAR_SIZE,
+                                       stmt_hash, DOMAIN_POK_SK,
+                                       strlen(DOMAIN_POK_SK)))
       goto cleanup;
-    memcpy(k, nonces, 32);
+    memcpy(k, nonces, kMPT_SCALAR_SIZE);
     OPENSSL_cleanse(nonces, sizeof(nonces));
   }
 
@@ -153,15 +154,15 @@ int secp256k1_mpt_pok_sk_prove(const secp256k1_context *ctx,
   compute_sigma_response(s, k, e, sk);
 
   /* 5. Serialize: e || s */
-  memcpy(proof_out, e, 32);
-  memcpy(proof_out + 32, s, 32);
+  memcpy(proof_out, e, kMPT_SCALAR_SIZE);
+  memcpy(proof_out + 32, s, kMPT_SCALAR_SIZE);
 
   ok = 1;
 
 cleanup:
-  OPENSSL_cleanse(k, 32);
-  OPENSSL_cleanse(e, 32);
-  OPENSSL_cleanse(s, 32);
+  OPENSSL_cleanse(k, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(e, kMPT_SCALAR_SIZE);
+  OPENSSL_cleanse(s, kMPT_SCALAR_SIZE);
   return ok;
 }
 
@@ -177,12 +178,13 @@ int secp256k1_mpt_pok_sk_verify(const secp256k1_context *ctx,
   MPT_ARG_CHECK(pk != NULL);
   /* context_id is optional */
 
-  unsigned char e[32], s[32], e_prime[32], neg_e[32];
+  unsigned char e[kMPT_SCALAR_SIZE], s[kMPT_SCALAR_SIZE];
+  unsigned char e_prime[kMPT_SCALAR_SIZE], neg_e[kMPT_SCALAR_SIZE];
   secp256k1_pubkey T;
 
   /* 1. Deserialize: e || s */
-  memcpy(e, proof, 32);
-  memcpy(s, proof + 32, 32);
+  memcpy(e, proof, kMPT_SCALAR_SIZE);
+  memcpy(s, proof + 32, kMPT_SCALAR_SIZE);
 
   if (!secp256k1_ec_seckey_verify(ctx, e))
     return 0;
@@ -209,5 +211,5 @@ int secp256k1_mpt_pok_sk_verify(const secp256k1_context *ctx,
     return 0;
 
   /* 4. Accept iff e' == e */
-  return CRYPTO_memcmp(e, e_prime, 32) == 0;
+  return CRYPTO_memcmp(e, e_prime, kMPT_SCALAR_SIZE) == 0;
 }

--- a/src/proof_pok_sk.c
+++ b/src/proof_pok_sk.c
@@ -26,8 +26,8 @@ static int build_pok_challenge(const secp256k1_context *ctx,
                                const unsigned char *context_id)
 {
   EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
-  unsigned char buf[33];
-  unsigned char h[32];
+  unsigned char buf[kMPT_PUBKEY_SIZE];
+  unsigned char h[kMPT_HALF_SHA_SIZE];
   size_t len;
   int ok = 0;
 
@@ -42,12 +42,12 @@ static int build_pok_challenge(const secp256k1_context *ctx,
 #define SER(pk_ptr)                                                            \
   do                                                                           \
   {                                                                            \
-    len = 33;                                                                  \
+    len = kMPT_PUBKEY_SIZE;                                                    \
     if (!secp256k1_ec_pubkey_serialize(ctx, buf, &len, pk_ptr,                 \
                                        SECP256K1_EC_COMPRESSED) ||             \
-        len != 33)                                                             \
+        len != kMPT_PUBKEY_SIZE)                                               \
       goto cleanup;                                                            \
-    if (EVP_DigestUpdate(mdctx, buf, 33) != 1)                                 \
+    if (EVP_DigestUpdate(mdctx, buf, kMPT_PUBKEY_SIZE) != 1)                   \
       goto cleanup;                                                            \
   } while (0)
 
@@ -58,7 +58,7 @@ static int build_pok_challenge(const secp256k1_context *ctx,
 
   if (context_id)
   {
-    if (EVP_DigestUpdate(mdctx, context_id, 32) != 1)
+    if (EVP_DigestUpdate(mdctx, context_id, kMPT_HALF_SHA_SIZE) != 1)
       goto cleanup;
   }
 
@@ -96,10 +96,10 @@ int secp256k1_mpt_pok_sk_prove(const secp256k1_context *ctx,
 
   /* 1. Deterministic nonce */
   {
-    unsigned char stmt_hash[32];
+    unsigned char stmt_hash[kMPT_HALF_SHA_SIZE];
     {
       EVP_MD_CTX *sh = EVP_MD_CTX_new();
-      unsigned char sbuf[33];
+      unsigned char sbuf[kMPT_PUBKEY_SIZE];
       size_t slen;
       if (!sh)
         goto cleanup;
@@ -108,22 +108,22 @@ int secp256k1_mpt_pok_sk_prove(const secp256k1_context *ctx,
         EVP_MD_CTX_free(sh);
         goto cleanup;
       }
-      slen = 33;
+      slen = kMPT_PUBKEY_SIZE;
       if (!secp256k1_ec_pubkey_serialize(ctx, sbuf, &slen, pk,
                                          SECP256K1_EC_COMPRESSED) ||
-          slen != 33)
+          slen != kMPT_PUBKEY_SIZE)
       {
         EVP_MD_CTX_free(sh);
         goto cleanup;
       }
-      if (EVP_DigestUpdate(sh, sbuf, 33) != 1)
+      if (EVP_DigestUpdate(sh, sbuf, kMPT_PUBKEY_SIZE) != 1)
       {
         EVP_MD_CTX_free(sh);
         goto cleanup;
       }
       if (context_id)
       {
-        if (EVP_DigestUpdate(sh, context_id, 32) != 1)
+        if (EVP_DigestUpdate(sh, context_id, kMPT_HALF_SHA_SIZE) != 1)
         {
           EVP_MD_CTX_free(sh);
           goto cleanup;


### PR DESCRIPTION
> **Stacked on #79.** This PR's diff against \`main\` includes #79's commits as well; review it after #79 merges, or look at the head commit (\`68d5d030\`) in isolation.

## Summary

Adds a dedicated \`kMPT_SCALAR_SIZE = 32\` constant in \`mpt_protocol.h\` and replaces the literal \`32\` at every site where it represents a secp256k1 scalar (challenge, response, nonce, witness, blinding factor) — disambiguating it from the SHA-256 output size that #79 already named with \`kMPT_HALF_SHA_SIZE\`. The two values are numerically equal but semantically distinct ("element of Z_q" vs. "hash output"); calling them by different names makes the intent of each site explicit, which is exactly what the audit issue asked for.

## What was changed

In \`include/mpt_protocol.h\`:
- New \`#define kMPT_SCALAR_SIZE 32\` with a comment explaining its relationship to \`kMPT_HALF_SHA_SIZE\`.

In each of \`commitments.c\`, \`elgamal.c\`, \`proof_pok_sk.c\`, \`proof_compact_standard.c\`, \`proof_compact_clawback.c\`, \`proof_compact_convertback.c\`, swept:
- Scalar buffer declarations (\`alpha[32]\`, \`beta[32]\`, \`gamma[32]\`, \`delta[32]\`, \`epsilon[32]\`, \`m_scalar[32]\`, \`b_scalar[32]\`, \`e[32]\`, \`z_*[32]\`, \`t_*[32]\`, \`witness_buf[N*32]\`, \`nonces[N*32]\`, \`one[32]\`, \`neg_one[32]\`, \`deterministic_scalar[32]\`).
- Scalar-sized \`memcpy(..., 32)\` size arguments (both prover packing and verifier unpacking).
- \`OPENSSL_cleanse(scalar, 32)\` cleanup calls.
- \`CRYPTO_memcmp(e, e_prime, 32)\` constant-time challenge equality.
- \`generate_deterministic_nonces(... sk, 32, ...)\` witness-length argument.
- \`one[31] = 1\` little-endian-one initialization (now \`one[kMPT_SCALAR_SIZE - 1] = 1\`).

## Out of scope

- **Positional offsets** into \`proof_out\` / \`proof\` (\`+ 32\`, \`+ 64\`, \`+ 96\`, ...): these encode the proof layout, not a single scalar size. Replacing with \`+ kMPT_SCALAR_SIZE\`, \`+ 2*kMPT_SCALAR_SIZE\`, ... is more visual noise than clarification, and a per-proof offset constant family (\`kMPT_COMPACT_STANDARD_OFFSET_Z_M\`, etc.) is a separate design call. Same scope rule as #79.
- \`src/bulletproof_aggregated.c\`: dense, performance-critical, lots of local sentinels and \`enum\` constants already; deserves its own PR.

## Test plan
- [x] \`cmake --build build-debug\` — clean, no new warnings.
- [x] \`ctest --output-on-failure\` — 10/10 pass.
- [x] \`pre-commit run --all-files\` — all hooks pass.

Closes more of #64.