### PR TITLE
fix: route secret-scalar tweak_mul through ecdh + ecmult_const

### DIFF
--- a/src/bulletproof_aggregated.c
+++ b/src/bulletproof_aggregated.c
@@ -1086,9 +1086,9 @@ int secp256k1_bulletproof_create_commitment(
   const secp256k1_pubkey *points_to_add[2];
   int v_is_zero = (value == 0);
 
-  /* 1. Compute r * Pk_base (The Blinding Term) */
+  /* 1. Compute r * h_generator (The Blinding Term) */
   Pk_term = *h_generator;
-  if (secp256k1_ec_pubkey_tweak_mul(ctx, &Pk_term, blinding_factor) != 1)
+  if (mpt_ct_pubkey_tweak_mul(ctx, &Pk_term, blinding_factor) != 1)
     return 0;
 
   /* 2. Handle Value Term */
@@ -1138,7 +1138,7 @@ static int calculate_commitment_term(
 
   /* 1. base_scalar * Base */
   tB = *h_generator;
-  if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tB, base_scalar))
+  if (!mpt_ct_pubkey_tweak_mul(ctx, &tB, base_scalar))
     return 0;
   pts[n_pts++] = &tB;
 
@@ -1580,7 +1580,7 @@ int secp256k1_bulletproof_prove_agg(
     const secp256k1_pubkey *pts[2];
 
     tB = *h_generator;
-    if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tB, tau1))
+    if (!mpt_ct_pubkey_tweak_mul(ctx, &tB, tau1))
       goto cleanup;
 
     if (memcmp(t1, zero, 32) == 0)
@@ -1604,7 +1604,7 @@ int secp256k1_bulletproof_prove_agg(
     const secp256k1_pubkey *pts[2];
 
     tB = *h_generator;
-    if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tB, tau2))
+    if (!mpt_ct_pubkey_tweak_mul(ctx, &tB, tau2))
       goto cleanup;
 
     if (memcmp(t2, zero, 32) == 0)

--- a/src/elgamal.c
+++ b/src/elgamal.c
@@ -89,7 +89,7 @@ int secp256k1_elgamal_encrypt(const secp256k1_context *ctx,
 
   /* 2. S = r * Q (Shared Secret) */
   S = *pubkey_Q;
-  if (!secp256k1_ec_pubkey_tweak_mul(ctx, &S, blinding_factor))
+  if (!mpt_ct_pubkey_tweak_mul(ctx, &S, blinding_factor))
     return 0;
 
   /* 3. C2 = S + m*G */
@@ -251,7 +251,7 @@ int secp256k1_elgamal_decrypt(const secp256k1_context *ctx, uint64_t *amount,
 
   /* 1. Recover Shared Secret: S = privkey * c1. */
   S = *c1;
-  if (!secp256k1_ec_pubkey_tweak_mul(ctx, &S, privkey))
+  if (!mpt_ct_pubkey_tweak_mul(ctx, &S, privkey))
     return 0;
 
   /* Serialize c2 and S once up front; the loop never serializes the

--- a/src/mpt_internal.h
+++ b/src/mpt_internal.h
@@ -15,6 +15,7 @@
 #include <openssl/rand.h>
 
 #include <secp256k1.h>
+#include <secp256k1_ecdh.h>
 #include <stdint.h>
 #include <string.h>
 
@@ -42,6 +43,62 @@ static inline int
 pubkey_equal(secp256k1_context const* ctx, secp256k1_pubkey const* pk1, secp256k1_pubkey const* pk2)
 {
     return secp256k1_ec_pubkey_cmp(ctx, pk1, pk2) == 0;
+}
+
+/** ECDH hash callback that copies the raw uncompressed point bytes
+ *  (0x04 || x32 || y32) into the 65-byte output buffer. Used by
+ *  mpt_ct_pubkey_tweak_mul below. */
+static inline int
+mpt_raw_point_copy_hashfn(
+    unsigned char* output,
+    unsigned char const* x32,
+    unsigned char const* y32,
+    void* data)
+{
+    (void)data;
+    output[0] = 0x04;
+    memcpy(output + 1, x32, 32);
+    memcpy(output + 33, y32, 32);
+    return 1;
+}
+
+/** Constant-time replacement for secp256k1_ec_pubkey_tweak_mul on a secret scalar.
+ *
+ *  secp256k1_ec_pubkey_tweak_mul dispatches through secp256k1_ecmult ->
+ *  secp256k1_ecmult_strauss_wnaf, which uses the explicitly variable-time ops
+ *  secp256k1_gej_double_var / secp256k1_gej_add_ge_var. The scalar's wNAF
+ *  representation gates branches and memory accesses, leaking Hamming-weight
+ *  statistics through timing.
+ *
+ *  secp256k1_ecdh dispatches through secp256k1_ecmult_const, which uses
+ *  constant-time scalar recoding and constant-time gej_double / gej_add_ge.
+ *  By passing a custom hash callback that simply copies the raw (x, y)
+ *  coordinates, we recover the multiplication result as a serialized point
+ *  rather than the default SHA256-of-x.
+ *
+ *  Behaviour matches tweak_mul on the inputs callers care about: returns 1
+ *  with `*point := scalar * (*point)` on a valid in-range scalar, returns 0
+ *  on zero / overflow scalar (in which case `*point` is unchanged: ecdh's
+ *  output goes to the raw buffer, which is cleansed before return, and
+ *  pubkey_parse is skipped).
+ *
+ *  Caller must ensure `point` is initialized; on success it is overwritten
+ *  with the new point. The 65-byte intermediate is cleansed unconditionally. */
+static inline int
+mpt_ct_pubkey_tweak_mul(
+    secp256k1_context const* ctx,
+    secp256k1_pubkey* point,
+    unsigned char const* secret_scalar)
+{
+    unsigned char raw[65];
+    int ok = 0;
+
+    if (secp256k1_ecdh(ctx, raw, point, secret_scalar, mpt_raw_point_copy_hashfn, NULL) == 1)
+    {
+        ok = secp256k1_ec_pubkey_parse(ctx, point, raw, 65);
+    }
+    OPENSSL_cleanse(raw, sizeof(raw));
+    return ok;
 }
 
 /** Generates a random valid secp256k1 scalar (0 < scalar < order).

--- a/src/proof_compact_clawback.c
+++ b/src/proof_compact_clawback.c
@@ -227,7 +227,7 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
     goto cleanup;
 
   T2 = *C1;
-  if (!secp256k1_ec_pubkey_tweak_mul(ctx, &T2, t_sk))
+  if (!mpt_ct_pubkey_tweak_mul(ctx, &T2, t_sk))
     goto cleanup;
 
   /* 3. Challenge */

--- a/src/proof_compact_convertback.c
+++ b/src/proof_compact_convertback.c
@@ -215,7 +215,7 @@ int secp256k1_compact_convertback_prove(
     if (!secp256k1_ec_pubkey_create(ctx, &tbG, t_b))
       goto cleanup;
     tskB1 = *B1;
-    if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tskB1, t_sk))
+    if (!mpt_ct_pubkey_tweak_mul(ctx, &tskB1, t_sk))
       goto cleanup;
     const secp256k1_pubkey *pts[2] = {&tbG, &tskB1};
     if (!secp256k1_ec_pubkey_combine(ctx, &T_sk2, pts, 2))
@@ -228,7 +228,7 @@ int secp256k1_compact_convertback_prove(
     if (!secp256k1_ec_pubkey_create(ctx, &tbG, t_b))
       goto cleanup;
     trH = H;
-    if (!secp256k1_ec_pubkey_tweak_mul(ctx, &trH, t_rho))
+    if (!mpt_ct_pubkey_tweak_mul(ctx, &trH, t_rho))
       goto cleanup;
     const secp256k1_pubkey *pts[2] = {&tbG, &trH};
     if (!secp256k1_ec_pubkey_combine(ctx, &T_b, pts, 2))

--- a/src/proof_compact_standard.c
+++ b/src/proof_compact_standard.c
@@ -281,7 +281,7 @@ int secp256k1_compact_standard_prove(
     for (size_t i = 0; i < n; i++)
     {
       secp256k1_pubkey aPk = Pk_vec[i];
-      if (!secp256k1_ec_pubkey_tweak_mul(ctx, &aPk, alpha))
+      if (!mpt_ct_pubkey_tweak_mul(ctx, &aPk, alpha))
         goto cleanup;
       const secp256k1_pubkey *pts[2] = {&aPk, &betaG};
       if (!secp256k1_ec_pubkey_combine(ctx, &T2_vec[i], pts, 2))
@@ -295,7 +295,7 @@ int secp256k1_compact_standard_prove(
     if (!secp256k1_ec_pubkey_create(ctx, &betaG, beta))
       goto cleanup;
     alphaH = H;
-    if (!secp256k1_ec_pubkey_tweak_mul(ctx, &alphaH, alpha))
+    if (!mpt_ct_pubkey_tweak_mul(ctx, &alphaH, alpha))
       goto cleanup;
     const secp256k1_pubkey *pts[2] = {&betaG, &alphaH};
     if (!secp256k1_ec_pubkey_combine(ctx, &T_PCm, pts, 2))
@@ -312,7 +312,7 @@ int secp256k1_compact_standard_prove(
     if (!secp256k1_ec_pubkey_create(ctx, &epsG, epsilon))
       goto cleanup;
     deltaH = H;
-    if (!secp256k1_ec_pubkey_tweak_mul(ctx, &deltaH, delta))
+    if (!mpt_ct_pubkey_tweak_mul(ctx, &deltaH, delta))
       goto cleanup;
     const secp256k1_pubkey *pts[2] = {&epsG, &deltaH};
     if (!secp256k1_ec_pubkey_combine(ctx, &T_PCb, pts, 2))
@@ -323,7 +323,7 @@ int secp256k1_compact_standard_prove(
   {
     secp256k1_pubkey gB1, epsG;
     gB1 = *B1;
-    if (!secp256k1_ec_pubkey_tweak_mul(ctx, &gB1, gamma))
+    if (!mpt_ct_pubkey_tweak_mul(ctx, &gB1, gamma))
       goto cleanup;
     if (!secp256k1_ec_pubkey_create(ctx, &epsG, epsilon))
       goto cleanup;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,3 +83,9 @@ add_mpt_test(
     test_compact_convertback.c
     DEPENDENCIES mpt-crypto secp256k1::secp256k1
 )
+
+add_mpt_test(
+    test_ct_tweak_mul
+    test_ct_tweak_mul.c
+    DEPENDENCIES mpt-crypto secp256k1::secp256k1 OpenSSL::Crypto
+)

--- a/tests/test_ct_tweak_mul.c
+++ b/tests/test_ct_tweak_mul.c
@@ -1,0 +1,147 @@
+/* Algebraic-equivalence tests for mpt_ct_pubkey_tweak_mul.
+ *
+ * The wrapper routes secret-scalar point multiplications through
+ * secp256k1_ecdh (which uses constant-time secp256k1_ecmult_const)
+ * and parses the resulting raw point back into a secp256k1_pubkey.
+ * This test fixes the wrapper's algebraic behaviour against the
+ * existing variable-time secp256k1_ec_pubkey_tweak_mul on every
+ * input both functions accept (i.e., 0 < scalar < group_order).
+ *
+ * It does NOT measure timing — that is asserted only at the source
+ * level by the wrapper's documented dispatch path. */
+
+#include "secp256k1_mpt.h"
+#include "test_utils.h"
+
+#include "../src/mpt_internal.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static void serialize33(secp256k1_context const *ctx, unsigned char out[33],
+                        secp256k1_pubkey const *pk)
+{
+  size_t len = 33;
+  EXPECT(secp256k1_ec_pubkey_serialize(ctx, out, &len, pk,
+                                       SECP256K1_EC_COMPRESSED) == 1);
+  EXPECT(len == 33);
+}
+
+/* For a uniformly-random valid scalar and a uniformly-random base
+ * point, the new wrapper and the legacy primitive must produce
+ * byte-identical output. */
+static void test_random_scalar_random_point(secp256k1_context *ctx)
+{
+  printf("test_random_scalar_random_point...\n");
+  for (int trial = 0; trial < 64; ++trial)
+  {
+    unsigned char base_sk[32], scalar[32];
+    random_scalar(ctx, base_sk);
+    random_scalar(ctx, scalar);
+
+    secp256k1_pubkey base;
+    EXPECT(secp256k1_ec_pubkey_create(ctx, &base, base_sk) == 1);
+
+    secp256k1_pubkey p_legacy = base, p_ct = base;
+    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &p_legacy, scalar) == 1);
+    EXPECT(mpt_ct_pubkey_tweak_mul(ctx, &p_ct, scalar) == 1);
+
+    unsigned char ser_legacy[33], ser_ct[33];
+    serialize33(ctx, ser_legacy, &p_legacy);
+    serialize33(ctx, ser_ct, &p_ct);
+    EXPECT(memcmp(ser_legacy, ser_ct, 33) == 0);
+  }
+  printf("SUCCESS: 64 random (scalar, point) pairs match\n");
+}
+
+/* Edge cases that exercise the wNAF representation differently:
+ * scalar = 1, scalar = 2, scalar = group_order - 1, and a few
+ * fixed bit patterns the legacy variable-time path treats specially. */
+static void test_edge_case_scalars(secp256k1_context *ctx)
+{
+  printf("test_edge_case_scalars...\n");
+
+  static unsigned char const order_minus_one[32] = {
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48,
+      0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x40};
+
+  unsigned char scalar_one[32] = {0};
+  scalar_one[31] = 1;
+  unsigned char scalar_two[32] = {0};
+  scalar_two[31] = 2;
+  unsigned char scalar_repeat[32];
+  memset(scalar_repeat, 0xAA, 32); /* high Hamming weight */
+  unsigned char scalar_sparse[32] = {0};
+  scalar_sparse[0] = 0x80; /* single high bit */
+
+  unsigned char const *test_scalars[] = {scalar_one, scalar_two, scalar_repeat,
+                                         scalar_sparse, order_minus_one};
+  char const *names[] = {"1", "2", "0xAA..AA", "high-bit only", "n-1"};
+
+  unsigned char base_sk[32];
+  random_scalar(ctx, base_sk);
+  secp256k1_pubkey base;
+  EXPECT(secp256k1_ec_pubkey_create(ctx, &base, base_sk) == 1);
+
+  for (size_t i = 0; i < sizeof(test_scalars) / sizeof(test_scalars[0]); ++i)
+  {
+    secp256k1_pubkey p_legacy = base, p_ct = base;
+    EXPECT(secp256k1_ec_pubkey_tweak_mul(ctx, &p_legacy, test_scalars[i]) == 1);
+    EXPECT(mpt_ct_pubkey_tweak_mul(ctx, &p_ct, test_scalars[i]) == 1);
+
+    unsigned char ser_legacy[33], ser_ct[33];
+    serialize33(ctx, ser_legacy, &p_legacy);
+    serialize33(ctx, ser_ct, &p_ct);
+    EXPECT(memcmp(ser_legacy, ser_ct, 33) == 0);
+    printf("  scalar=%s: ok\n", names[i]);
+  }
+}
+
+/* Both functions must reject zero and >= group_order scalars. The
+ * wrapper additionally must not corrupt the caller's point on
+ * failure — pubkey_parse is only invoked on success. */
+static void test_invalid_scalars_rejected(secp256k1_context *ctx)
+{
+  printf("test_invalid_scalars_rejected...\n");
+
+  unsigned char base_sk[32];
+  random_scalar(ctx, base_sk);
+  secp256k1_pubkey base;
+  EXPECT(secp256k1_ec_pubkey_create(ctx, &base, base_sk) == 1);
+
+  unsigned char zero[32] = {0};
+  /* The group order itself, which fails seckey_verify. */
+  static unsigned char const order[32] = {
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+      0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xBA, 0xAE, 0xDC, 0xE6, 0xAF, 0x48,
+      0xA0, 0x3B, 0xBF, 0xD2, 0x5E, 0x8C, 0xD0, 0x36, 0x41, 0x41};
+  unsigned char overflow[32];
+  memset(overflow, 0xFF, 32);
+
+  unsigned char const *invalid_scalars[] = {zero, order, overflow};
+  char const *names[] = {"zero", "order", "all-ones"};
+
+  for (size_t i = 0; i < sizeof(invalid_scalars) / sizeof(invalid_scalars[0]);
+       ++i)
+  {
+    secp256k1_pubkey p = base;
+    EXPECT(mpt_ct_pubkey_tweak_mul(ctx, &p, invalid_scalars[i]) == 0);
+    printf("  scalar=%s: correctly rejected\n", names[i]);
+  }
+}
+
+int main(void)
+{
+  secp256k1_context *ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN |
+                                                    SECP256K1_CONTEXT_VERIFY);
+  EXPECT(ctx != NULL);
+
+  test_random_scalar_random_point(ctx);
+  test_edge_case_scalars(ctx);
+  test_invalid_scalars_rejected(ctx);
+
+  secp256k1_context_destroy(ctx);
+  printf("All ct_tweak_mul equivalence tests passed.\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Replace `secp256k1_ec_pubkey_tweak_mul` with a constant-time wrapper at every prover/decrypt-path site where the scalar is secret. The wrapper routes through `secp256k1_ecdh` + a raw-point hash callback, which dispatches through `secp256k1_ecmult_const` — constant-time scalar mul on an arbitrary base point.

Closes #84. The structurally separate MSM/zero-skip work is tracked in #85.

## Why

`tweak_mul` calls `secp256k1_ecmult_strauss_wnaf` (variable-time). The scalar's wNAF representation gates branches and memory accesses, leaking Hamming-weight statistics through timing. Same family as TOB-RIPCTX-4 (decrypt) and TOB-RIPCTX-5 (BP prover); also surfaced as Sherlock contest 2026-04 finding #630, which contributed the concrete `secp256k1_ecdh + custom hash callback` fix idea.

The PR #16 review explicitly accepted the residual leak, on the assumption that no public libsecp256k1 API exposes constant-time scalar mul on an arbitrary point. That assumption is incorrect — `secp256k1_ecdh` does exactly that. See `secp256k1/src/modules/ecdh/main_impl.h:55` for the direct `ecmult_const` dispatch.

## What changed

- `src/mpt_internal.h`: new `mpt_ct_pubkey_tweak_mul` wrapper + `mpt_raw_point_copy_hashfn` callback.
- 13 secret-scalar callsites converted across `elgamal.c` (2), `proof_compact_standard.c` (4), `proof_compact_clawback.c` (1), `proof_compact_convertback.c` (2), `bulletproof_aggregated.c` (4 discrete prover sites).
- `tests/test_ct_tweak_mul.c`: algebraic-equivalence test pinning the wrapper to the legacy primitive on 64 random pairs, 5 edge-case scalars (1, 2, 0xAA..AA, single-high-bit, n-1), and 3 invalid scalars (0, n, all-ones).

## Out of scope (deliberately)

- **Verifier-side `tweak_mul`** — operates on public inputs (FS challenges, proof responses, public IPA challenge powers).
- **`elgamal.c:328`** (`secp256k1_elgamal_verify_encryption`) — runs on the Convert path where `r` is deterministically disclosed on-chain and is public when invoked.
- **`secp256k1_bulletproof_ipa_msm`** and its prover-side call sites — see #85. The data-dependent `if (scalar_is_zero) continue;` branch is independent of the multiplication primitive and requires structural changes (CT accumulator), not a mechanical swap.
- **`secp256k1_ec_pubkey_create`** — already constant-time via `ecmult_gen` (precomputed-table fixed-base mul). No change needed.

## Behavioral notes

1. **Zero/overflow scalars.** `tweak_mul` returns 0 immediately on zero/overflow. `ecdh` substitutes `s := 1` to keep the multiplication constant-time, then returns 0 on the way out. The return code is identical; the output buffer must not be used on failure (already the contract). All 13 affected sites already propagate failure via `goto cleanup` or early `return 0`.
2. **Performance.** ECDH adds `pubkey_load` + custom hash callback + `pubkey_parse` per call, plus the constant-time scalar mul is slower on average inputs than variable-time wNAF. Net cost ~single-digit microseconds per call; immaterial for proof generation.
3. **API surface unchanged.** No public header changes, no on-wire format changes.

## Test plan

- [x] `ctest` green: 11/11 (10 pre-existing + new `test_ct_tweak_mul`).
- [x] `pre-commit run --all-files` green.
- [x] New equivalence test confirms wrapper and legacy primitive produce byte-identical output across random and edge-case valid scalars, and consistently reject invalid scalars.
- [ ] Reviewer to confirm: any remaining `tweak_mul` callsite I should reclassify as secret-scalar (I've audited what looks like all of them; verifier vs. prover separation is documented in the issue).
