### PR TITLE
chore(deps): bump openssl 3.5.5 -> 3.5.6

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ class MptCryptoConan(ConanFile):
     }
 
     requires = [
-        "openssl/3.5.5",
+        "openssl/3.5.6",
         "secp256k1/0.7.1",
     ]
 


### PR DESCRIPTION
Unblocks CI for every PR (and `main` itself).

## Why

The xrplf Conan remote published a new recipe revision of
`openssl/3.5.5` on **2026-05-06 10:01 UTC**
(revision `4789bbf131b77d0515d15e094c8f697f`). The new revision's
`conandata.yml` no longer lists `3.5.5` as a source key — only `3.5.6`
(plus `3.4.5`, `3.3.7`, `3.2.6`, `3.1.2`, `3.0.20`). Every Conan
install against that remote now fails in the recipe's `source()`
method with:

```
ERROR: openssl/3.5.5: Error in source() method, line 154
    get(self, **self.conan_data["sources"][self.version], strip_root=True)
    KeyError: '3.5.5'
```

This is not a flake. The failure is deterministic, identical
across every matrix entry, and reproducible on unchanged code:

- `main@85891ab4` was green on 2026-04-28.
- Re-running the apple-clang Release job from that build today
  fails in 23 s with the same `KeyError`.

The remote-side change reads as a security-driven nudge from
3.5.5 to 3.5.6 that broke any consumer still pinned to 3.5.5.
This PR takes the nudge — also picks up whichever upstream fix
in 3.5.6 motivated the bump.

## Verified locally

- `conan install` succeeds with `openssl/3.5.6`.
- Full CMake build (Release, apple-clang) succeeds.
- All 10 tests pass.

## Scope

One-line change to `conanfile.py`. Nothing else touched.