### PR TITLE
docs(bp): rename pk_base → h_generator and correct doxygen

### DIFF
--- a/include/secp256k1_mpt.h
+++ b/include/secp256k1_mpt.h
@@ -92,16 +92,25 @@ generate_canonical_encrypted_zero(
 );
 
 /**
- * @brief Computes a Pedersen Commitment: C = value*G + blinding_factor*Pk_base.
+ * @brief Computes a Pedersen Commitment: C = value*G + blinding_factor*H.
  *
  * This function creates the commitment point (C) that the Bulletproof proves
- * the range of. Pk_base is the dynamic secondary generator (H).
+ * the range of.
  *
  * @param[in]   ctx             A pointer to the context.
  * @param[out]  commitment_C    The resulting commitment point C.
  * @param[in]   value           The secret amount v (uint64_t).
  * @param[in]   blinding_factor The secret randomness r (32 bytes).
- * @param[in]   pk_base         The recipient's public key (used as the H generator).
+ * @param[in]   h_generator     The Pedersen blinding generator H, as returned
+ *                              by secp256k1_mpt_get_h_generator(). This MUST
+ *                              be the standardized nothing-up-my-sleeve H
+ *                              generator; it must NOT be a holder, issuer,
+ *                              auditor, or recipient encryption public key.
+ *                              Pedersen binding requires that the discrete
+ *                              log of H be unknown to all parties; supplying
+ *                              a key whose discrete log is known to any party
+ *                              breaks binding and lets that party compute
+ *                              alternate openings of the same commitment.
  *
  * @return 1 on success, 0 on failure.
  */
@@ -111,7 +120,7 @@ secp256k1_bulletproof_create_commitment(
     secp256k1_pubkey* commitment_C,
     uint64_t value,
     unsigned char const* blinding_factor,
-    secp256k1_pubkey const* pk_base);
+    secp256k1_pubkey const* h_generator);
 
 int
 secp256k1_bulletproof_prove(
@@ -120,7 +129,7 @@ secp256k1_bulletproof_prove(
     size_t* proof_len,
     uint64_t value,
     unsigned char const* blinding_factor,
-    secp256k1_pubkey const* pk_base,
+    secp256k1_pubkey const* h_generator,
     unsigned char const* context_id, /* <--- AND HERE */
     unsigned int proof_type);
 
@@ -132,7 +141,7 @@ secp256k1_bulletproof_verify(
     unsigned char const* proof,
     size_t proof_len,
     secp256k1_pubkey const* commitment_C,
-    secp256k1_pubkey const* pk_base, /* This is generator H */
+    secp256k1_pubkey const* h_generator, /* This is generator H */
     unsigned char const* context_id);
 /**
  * Verifies that (c1, c2) is a valid ElGamal encryption of 'amount'
@@ -213,7 +222,7 @@ secp256k1_bulletproof_prove_agg(
     uint64_t const* values,
     unsigned char const* blindings_flat,
     size_t m,
-    secp256k1_pubkey const* pk_base,
+    secp256k1_pubkey const* h_generator,
     unsigned char const* context_id);
 int
 secp256k1_bulletproof_verify_agg(
@@ -224,7 +233,7 @@ secp256k1_bulletproof_verify_agg(
     size_t proof_len,
     secp256k1_pubkey const* commitment_C_vec, /* length m */
     size_t m,
-    secp256k1_pubkey const* pk_base,
+    secp256k1_pubkey const* h_generator,
     unsigned char const* context_id);
 
 /*

--- a/src/bulletproof_aggregated.c
+++ b/src/bulletproof_aggregated.c
@@ -1080,14 +1080,14 @@ cleanup:
 int secp256k1_bulletproof_create_commitment(
     const secp256k1_context *ctx, secp256k1_pubkey *commitment_C,
     uint64_t value, const unsigned char *blinding_factor,
-    const secp256k1_pubkey *pk_base)
+    const secp256k1_pubkey *h_generator)
 {
   secp256k1_pubkey G_term, Pk_term;
   const secp256k1_pubkey *points_to_add[2];
   int v_is_zero = (value == 0);
 
   /* 1. Compute r * Pk_base (The Blinding Term) */
-  Pk_term = *pk_base;
+  Pk_term = *h_generator;
   if (secp256k1_ec_pubkey_tweak_mul(ctx, &Pk_term, blinding_factor) != 1)
     return 0;
 
@@ -1128,7 +1128,7 @@ static int scalar_vector_all_zero(const unsigned char *scalars, size_t n)
 /* Helper to calculate commitment terms like A and S */
 static int calculate_commitment_term(
     const secp256k1_context *ctx, secp256k1_pubkey *out,
-    const secp256k1_pubkey *pk_base, const unsigned char *base_scalar,
+    const secp256k1_pubkey *h_generator, const unsigned char *base_scalar,
     const unsigned char *vec_l, const unsigned char *vec_r,
     const secp256k1_pubkey *G_vec, const secp256k1_pubkey *H_vec, size_t n)
 {
@@ -1137,7 +1137,7 @@ static int calculate_commitment_term(
   int n_pts = 0;
 
   /* 1. base_scalar * Base */
-  tB = *pk_base;
+  tB = *h_generator;
   if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tB, base_scalar))
     return 0;
   pts[n_pts++] = &tB;
@@ -1180,7 +1180,7 @@ static int calculate_commitment_term(
  * - values: Array of m 64-bit integers to prove.
  * - blindings_flat: Array of m 32-byte blinding factors (one per value).
  * - m: Number of values to aggregate (must be a power of 2).
- * - pk_base: Generator H used for the commitments (C = vG + rH).
+ * - h_generator: Generator H used for the commitments (C = vG + rH).
  * - context_id: Optional 32-byte unique ID to bind the proof to a context.
  *
  * Outputs:
@@ -1189,12 +1189,10 @@ static int calculate_commitment_term(
  *
  * Returns 1 on success, 0 on failure.
  */
-int secp256k1_bulletproof_prove_agg(const secp256k1_context *ctx,
-                                    unsigned char *proof_out, size_t *proof_len,
-                                    const uint64_t *values,
-                                    const unsigned char *blindings_flat,
-                                    size_t m, const secp256k1_pubkey *pk_base,
-                                    const unsigned char *context_id)
+int secp256k1_bulletproof_prove_agg(
+    const secp256k1_context *ctx, unsigned char *proof_out, size_t *proof_len,
+    const uint64_t *values, const unsigned char *blindings_flat, size_t m,
+    const secp256k1_pubkey *h_generator, const unsigned char *context_id)
 {
   /* ---- 0. Dimensions ---- */
   const size_t n = BP_TOTAL_BITS(m);      /* 64*m */
@@ -1317,11 +1315,11 @@ int secp256k1_bulletproof_prove_agg(const secp256k1_context *ctx,
    * A = alpha*Base + <al,G> + <ar,H>
    * S = rho*Base   + <sl,G> + <sr,H>
    */
-  if (!calculate_commitment_term(ctx, &A, pk_base, alpha, al, ar, G_vec, H_vec,
-                                 n))
+  if (!calculate_commitment_term(ctx, &A, h_generator, alpha, al, ar, G_vec,
+                                 H_vec, n))
     goto cleanup;
-  if (!calculate_commitment_term(ctx, &S, pk_base, rho, sl, sr, G_vec, H_vec,
-                                 n))
+  if (!calculate_commitment_term(ctx, &S, h_generator, rho, sl, sr, G_vec,
+                                 H_vec, n))
     goto cleanup;
 
   /* ---- 6. Fiat–Shamir y,z ---- */
@@ -1370,7 +1368,7 @@ int secp256k1_bulletproof_prove_agg(const secp256k1_context *ctx,
       unsigned char V_ser[33];
       size_t v_len = 33;
       if (!secp256k1_bulletproof_create_commitment(
-              ctx, &V_temp, values[i], blindings_flat + 32 * i, pk_base))
+              ctx, &V_temp, values[i], blindings_flat + 32 * i, h_generator))
       {
         fs_ok = 0;
         goto fs_cleanup;
@@ -1429,7 +1427,7 @@ int secp256k1_bulletproof_prove_agg(const secp256k1_context *ctx,
       unsigned char V_ser[33];
       size_t v_len = 33;
       if (!secp256k1_bulletproof_create_commitment(
-              ctx, &V_temp, values[i], blindings_flat + 32 * i, pk_base))
+              ctx, &V_temp, values[i], blindings_flat + 32 * i, h_generator))
       {
         fs_ok = 0;
         goto fs_cleanup;
@@ -1581,7 +1579,7 @@ int secp256k1_bulletproof_prove_agg(const secp256k1_context *ctx,
     secp256k1_pubkey tG, tB;
     const secp256k1_pubkey *pts[2];
 
-    tB = *pk_base;
+    tB = *h_generator;
     if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tB, tau1))
       goto cleanup;
 
@@ -1605,7 +1603,7 @@ int secp256k1_bulletproof_prove_agg(const secp256k1_context *ctx,
     secp256k1_pubkey tG, tB;
     const secp256k1_pubkey *pts[2];
 
-    tB = *pk_base;
+    tB = *h_generator;
     if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tB, tau2))
       goto cleanup;
 
@@ -2059,9 +2057,10 @@ int secp256k1_bulletproof_verify_agg(
     const secp256k1_pubkey *H_vec, /* length n = 64*m */
     const unsigned char *proof, size_t proof_len,
     const secp256k1_pubkey *commitment_C_vec, /* length m */
-    size_t m, const secp256k1_pubkey *pk_base, const unsigned char *context_id)
+    size_t m, const secp256k1_pubkey *h_generator,
+    const unsigned char *context_id)
 {
-  if (!ctx || !G_vec || !H_vec || !proof || !commitment_C_vec || !pk_base)
+  if (!ctx || !G_vec || !H_vec || !proof || !commitment_C_vec || !h_generator)
     return 0;
   if (m == 0 || m > BP_MAX_VALUES)
     return 0;
@@ -2388,7 +2387,7 @@ fs_fail:
     }
     if (memcmp(tau_x, zero32, 32) != 0)
     {
-      tauH = *pk_base;
+      tauH = *h_generator;
       if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tauH, tau_x))
       {
         free(y_block_sum);
@@ -2725,7 +2724,7 @@ fs_fail:
     OPENSSL_cleanse(t_hat_ux, 32);
   }
 
-  /* P -= mu*pk_base */
+  /* P -= mu*h_generator */
   {
     unsigned char neg_mu[32];
     memcpy(neg_mu, mu, 32);
@@ -2737,7 +2736,7 @@ fs_fail:
       goto fail;
     }
 
-    secp256k1_pubkey mu_term = *pk_base;
+    secp256k1_pubkey mu_term = *h_generator;
     if (!secp256k1_ec_pubkey_tweak_mul(ctx, &mu_term, neg_mu))
     {
       OPENSSL_cleanse(neg_mu, 32);

--- a/src/utility/mpt_utility.cpp
+++ b/src/utility/mpt_utility.cpp
@@ -104,12 +104,13 @@ mpt_get_bulletproof_agg(
     }
 
     {
-        secp256k1_pubkey pk_base;
-        if (secp256k1_mpt_get_h_generator(ctx, &pk_base) != 1)
+        secp256k1_pubkey h_generator;
+        if (secp256k1_mpt_get_h_generator(ctx, &h_generator) != 1)
             goto bp_cleanup;
 
         if (secp256k1_bulletproof_prove_agg(
-                ctx, out_proof, out_len, values, blindings_flat, m, &pk_base, context_hash) != 1)
+                ctx, out_proof, out_len, values, blindings_flat, m, &h_generator, context_hash) !=
+            1)
             goto bp_cleanup;
 
         size_t const expected =
@@ -893,8 +894,8 @@ mpt_verify_aggregated_bulletproof(
         1)
         return -1;
 
-    secp256k1_pubkey pk_base;
-    if (secp256k1_mpt_get_h_generator(ctx, &pk_base) != 1)
+    secp256k1_pubkey h_generator;
+    if (secp256k1_mpt_get_h_generator(ctx, &h_generator) != 1)
         return -1;
 
     if (secp256k1_bulletproof_verify_agg(
@@ -905,7 +906,7 @@ mpt_verify_aggregated_bulletproof(
             proof_len,
             commitments.data(),
             m,
-            &pk_base,
+            &h_generator,
             context_hash) != 1)
     {
         return -1;

--- a/tests/test_bulletproof_agg.c
+++ b/tests/test_bulletproof_agg.c
@@ -30,15 +30,15 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
   EXPECT(blindings != NULL && commitments != NULL);
   EXPECT(RAND_bytes(context_id, 32) == 1);
 
-  secp256k1_pubkey pk_base;
-  EXPECT(secp256k1_mpt_get_h_generator(ctx, &pk_base));
+  secp256k1_pubkey h_generator;
+  EXPECT(secp256k1_mpt_get_h_generator(ctx, &h_generator));
 
   /* ---- Commitments ---- */
   for (size_t i = 0; i < num_values; i++)
   {
     random_scalar(ctx, blindings[i]);
     EXPECT(secp256k1_bulletproof_create_commitment(
-        ctx, &commitments[i], values[i], blindings[i], &pk_base));
+        ctx, &commitments[i], values[i], blindings[i], &h_generator));
   }
 
   /* ---- Generator vectors ---- */
@@ -61,7 +61,7 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
 
   EXPECT(secp256k1_bulletproof_prove_agg(ctx, proof, &proof_len, values,
                                          (const unsigned char *)blindings,
-                                         num_values, &pk_base, context_id));
+                                         num_values, &h_generator, context_id));
 
   timespec_get(&t_p_end, TIME_UTC);
   printf("  Proof size: %zu bytes\n", proof_len);
@@ -73,8 +73,8 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
   timespec_get(&t_v_start, TIME_UTC);
 
   int ok = secp256k1_bulletproof_verify_agg(ctx, G_vec, H_vec, proof, proof_len,
-                                            commitments, num_values, &pk_base,
-                                            context_id);
+                                            commitments, num_values,
+                                            &h_generator, context_id);
 
   timespec_get(&t_v_end, TIME_UTC);
   EXPECT(ok);
@@ -92,8 +92,8 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
       struct timespec ts, te;
       timespec_get(&ts, TIME_UTC);
       ok = secp256k1_bulletproof_verify_agg(ctx, G_vec, H_vec, proof, proof_len,
-                                            commitments, num_values, &pk_base,
-                                            context_id);
+                                            commitments, num_values,
+                                            &h_generator, context_id);
       timespec_get(&te, TIME_UTC);
       EXPECT(ok);
       total_ms += elapsed_ms(ts, te);
@@ -122,11 +122,11 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
       ctx, &bad_commitments[num_values - 1],
       (values[num_values - 1] == UINT64_MAX) ? values[num_values - 1] - 1
                                              : values[num_values - 1] + 1,
-      bad_blinding, &pk_base));
+      bad_blinding, &h_generator));
 
   ok = secp256k1_bulletproof_verify_agg(ctx, G_vec, H_vec, proof, proof_len,
-                                        bad_commitments, num_values, &pk_base,
-                                        context_id);
+                                        bad_commitments, num_values,
+                                        &h_generator, context_id);
   EXPECT(ok == 0);
   printf("  PASSED (Rejected tampered-value proof)\n");
 
@@ -144,11 +144,11 @@ void run_test_case(secp256k1_context *ctx, const char *name, uint64_t *values,
 
   EXPECT(secp256k1_bulletproof_create_commitment(
       ctx, &bad_commitments[num_values - 1], values[num_values - 1],
-      alt_blinding, &pk_base));
+      alt_blinding, &h_generator));
 
   ok = secp256k1_bulletproof_verify_agg(ctx, G_vec, H_vec, proof, proof_len,
-                                        bad_commitments, num_values, &pk_base,
-                                        context_id);
+                                        bad_commitments, num_values,
+                                        &h_generator, context_id);
   EXPECT(ok == 0);
   printf("  PASSED (Rejected same-value/different-blinding proof)\n");
 


### PR DESCRIPTION
Closes #91 / TOB-RIPCTXR-12.

## The misleading documentation

`secp256k1_bulletproof_create_commitment` in `include/secp256k1_mpt.h` documented `pk_base` as *"the recipient's public key (used as the H generator)"*. That description is wrong on a substantive point: the discrete log of `H` must not be known to any party, otherwise the Pedersen commitment binding property breaks (an attacker who knew `h = log_G H` could compute alternate openings of the same commitment).

The current high-level callers do supply the correct value — `secp256k1_mpt_get_h_generator()` is invoked at `src/utility/mpt_utility.cpp:107-113` before the `secp256k1_bulletproof_prove_agg` call — so the integrated flow is safe. The doc string was the risk: external callers reading the header literally could have supplied a holder/issuer/auditor pubkey and produced commitments with a publicly-known opening factor.

## What changed

- Parameter renamed `pk_base` → `h_generator` everywhere it appears, for consistency between the public API and its callers.
- Doxygen for `secp256k1_bulletproof_create_commitment` rewritten: states that the parameter must be the Pedersen blinding generator returned by `secp256k1_mpt_get_h_generator()`, and that supplying any encryption public key breaks Pedersen binding.
- Touched files: `include/secp256k1_mpt.h`, `src/bulletproof_aggregated.c`, `src/utility/mpt_utility.cpp`, `tests/test_bulletproof_agg.c`.
- `clang-format` reflowed several call sites because `h_generator` is longer than `pk_base`; no behavioural change.

Internal identifiers that contain "pk" but are not the parameter itself (e.g. `Pk_term` inside `calculate_commitment_term`) are deliberately left alone to keep this PR a single mechanical rename.

## Out of scope

The audit's long-term recommendation is to prefer APIs that derive the standardized generator internally rather than accepting it from the caller. That would be a separate API-redesign PR.

## Test plan

- [x] Build clean (`cmake --build --preset conan-debug`)
- [x] `ctest` — 10/10 pass
- [x] `pre-commit run --all-files` — all hooks pass

## References

- TOB revision audit (May 12, 2026), finding 12 (TOB-RIPCTXR-12).
- The nothing-up-my-sleeve construction in `secp256k1_mpt_get_h_generator()` is what the renamed parameter doc now points at.