### PR TITLE
fix: check unchecked OpenSSL return values in proof statement-hash and helpers

### DIFF
--- a/src/commitments.c
+++ b/src/commitments.c
@@ -73,7 +73,11 @@ int secp256k1_mpt_hash_to_point_nums(const secp256k1_context *ctx,
         (unsigned char)(ctr >> 24), (unsigned char)(ctr >> 16),
         (unsigned char)(ctr >> 8), (unsigned char)(ctr & 0xFF)};
 
-    EVP_MD_CTX_reset(mdctx);
+    if (EVP_MD_CTX_reset(mdctx) != 1)
+    {
+      EVP_MD_CTX_free(mdctx);
+      return 0;
+    }
     if (EVP_DigestInit_ex(mdctx, EVP_sha256(), NULL) != 1)
     {
       EVP_MD_CTX_free(mdctx);

--- a/src/proof_compact_clawback.c
+++ b/src/proof_compact_clawback.c
@@ -204,7 +204,12 @@ int secp256k1_compact_clawback_prove(const secp256k1_context *ctx,
           goto cleanup;
         }
       }
-      EVP_DigestFinal_ex(sh, stmt_hash, NULL);
+      if (EVP_DigestFinal_ex(sh, stmt_hash, NULL) != 1)
+      {
+        EVP_MD_CTX_free(sh);
+        OPENSSL_cleanse(witness_buf, sizeof(witness_buf));
+        goto cleanup;
+      }
       EVP_MD_CTX_free(sh);
 #undef SHASH
     }

--- a/src/proof_compact_convertback.c
+++ b/src/proof_compact_convertback.c
@@ -183,7 +183,12 @@ int secp256k1_compact_convertback_prove(
           goto cleanup;
         }
       }
-      EVP_DigestFinal_ex(sh, stmt_hash, NULL);
+      if (EVP_DigestFinal_ex(sh, stmt_hash, NULL) != 1)
+      {
+        EVP_MD_CTX_free(sh);
+        OPENSSL_cleanse(witness_buf, sizeof(witness_buf));
+        goto cleanup;
+      }
       EVP_MD_CTX_free(sh);
 #undef SHASH
     }

--- a/src/proof_compact_standard.c
+++ b/src/proof_compact_standard.c
@@ -245,7 +245,12 @@ int secp256k1_compact_standard_prove(
           goto cleanup;
         }
       }
-      EVP_DigestFinal_ex(sh, stmt_hash, NULL);
+      if (EVP_DigestFinal_ex(sh, stmt_hash, NULL) != 1)
+      {
+        EVP_MD_CTX_free(sh);
+        OPENSSL_cleanse(witness_buf, sizeof(witness_buf));
+        goto cleanup;
+      }
       EVP_MD_CTX_free(sh);
 #undef SHASH
     }

--- a/src/proof_pok_sk.c
+++ b/src/proof_pok_sk.c
@@ -129,7 +129,11 @@ int secp256k1_mpt_pok_sk_prove(const secp256k1_context *ctx,
           goto cleanup;
         }
       }
-      EVP_DigestFinal_ex(sh, stmt_hash, NULL);
+      if (EVP_DigestFinal_ex(sh, stmt_hash, NULL) != 1)
+      {
+        EVP_MD_CTX_free(sh);
+        goto cleanup;
+      }
       EVP_MD_CTX_free(sh);
     }
 

--- a/src/utility/mpt_utility.cpp
+++ b/src/utility/mpt_utility.cpp
@@ -210,6 +210,16 @@ sha512_half(uint8_t const* data, size_t len, uint8_t* out)
     unsigned int digest_len = 0;
     if (EVP_Digest(data, len, full_hash, &digest_len, EVP_sha512(), NULL) != 1)
         return -1;
+    // SHA-512 produces 64 bytes; we copy out the upper half (32 bytes).
+    // Verify the digest is at least the expected size before copying so a
+    // surprise digest-length mismatch cannot leak adjacent stack bytes or
+    // produce a truncated context hash that downstream callers then bind
+    // proofs against.
+    if (digest_len < 32)
+    {
+        OPENSSL_cleanse(full_hash, sizeof(full_hash));
+        return -1;
+    }
     memcpy(out, full_hash, 32);
     OPENSSL_cleanse(full_hash, sizeof(full_hash));
     return 0;


### PR DESCRIPTION
Closes #93 / TOB-RIPCTXR-14 (the subset beyond PR #76).

PR #76 added return-value checks for the EVP_MAC chain in `generate_deterministic_nonces`. This PR covers the remaining sites the May 2026 Trail of Bits revision audit (TOB-RIPCTXR-14) flagged.

## Sites covered

1. **Statement-hash finalization in all four compact provers.** `EVP_DigestFinal_ex(sh, stmt_hash, NULL)` was called without checking the return code in:
   - `secp256k1_mpt_pok_sk_prove` (`src/proof_pok_sk.c`, ~L132)
   - `secp256k1_compact_standard_prove` (`src/proof_compact_standard.c`, ~L248)
   - `secp256k1_compact_convertback_prove` (`src/proof_compact_convertback.c`, ~L186)
   - `secp256k1_compact_clawback_prove` (`src/proof_compact_clawback.c`, ~L207)

   Each now branches to `cleanup` on failure, freeing the `EVP_MD_CTX` and (in the three compact provers that hold a witness buffer in scope) cleansing `witness_buf` before the goto. This matches the cleanup pattern the surrounding `EVP_DigestUpdate` failure branches already use.

2. **`sha512_half` digest-length check** (`src/utility/mpt_utility.cpp`). `EVP_Digest(..., &digest_len, EVP_sha512(), NULL)` returned 64 bytes in practice, but no check verified `digest_len >= 32` before `memcpy(out, full_hash, 32)`. A surprise short digest would have either leaked adjacent stack bytes or produced a truncated context hash that callers then bind proofs against. Now returns `-1` (with `OPENSSL_cleanse` on the partial buffer) if `digest_len < 32`.

3. **`EVP_MD_CTX_reset` in `secp256k1_mpt_hash_to_point_nums`** (`src/commitments.c`). The reset call returns 1/0 like the rest of the `EVP_MD_CTX_*` family; previously its return value was ignored. Now branches to error cleanup on failure, matching the subsequent `EVP_DigestInit_ex` check.

## Out of scope

- The EVP_MAC chain in `generate_deterministic_nonces` is handled by PR #76 (open).
- Static-analysis rule (Semgrep / CodeQL) for unchecked `EVP_*` return values — the audit's long-term Appendix-G recommendation. Tracked separately.

## Test plan

- [x] Build clean (`cmake --build --preset conan-debug`)
- [x] `ctest` — 10/10 pass
- [x] `pre-commit run --all-files` — all hooks pass

## References

- TOB revision audit (May 12, 2026), finding 14 (TOB-RIPCTXR-14).
- PR #76 (handles the EVP_MAC subset).