### PR TITLE
feat(elgamal): add configurable [range_low, range_high] to secp256k1_elgamal_decrypt

### DIFF
--- a/include/secp256k1_mpt.h
+++ b/include/secp256k1_mpt.h
@@ -33,33 +33,42 @@ secp256k1_elgamal_encrypt(
 /**
  * @brief Decrypts an ElGamal ciphertext to recover the amount.
  *
- * The function uses a linear discrete-logarithm search over a fixed range
- * and can only successfully recover plaintext amounts in [0, 1,000,000].
- * If the ciphertext encrypts a value greater than 1,000,000 the search
- * exhausts its range and the function returns 0 (not found).  Callers
- * that read the public API contract as supporting arbitrary 64-bit
- * amounts should not rely on this function for those cases.
+ * The function uses a linear discrete-logarithm search over the caller-
+ * specified range [range_low, range_high] and can only successfully recover
+ * plaintext amounts within that range. If the ciphertext encrypts a value
+ * outside the range, the search exhausts its iterations and the function
+ * returns 0 (not found). The recommended default range is [0, 1,000,000].
  *
  * To mitigate amount-dependent timing side channels (TOB-RIPCTX-1 / -4,
  * reintroduced as TOB-RIPCTXR-1), the search executes with a fixed
- * iteration count: it always runs to the maximum of 1,000,000 iterations
- * regardless of where (or whether) the match is found.  This is a fixed
- * iteration count, not strict constant time: the underlying libsecp256k1
- * curve operations are inherently variable-time, so this function does
- * not protect against attackers that can observe microarchitectural
- * variation of individual point operations.  In shared / multitenant
- * deployments where such attacks are relevant, callers should not
- * expose decryption latency to untrusted observers.
+ * iteration count: it always runs to completion over the full specified
+ * range regardless of where (or whether) the match is found. This is a
+ * fixed iteration count, not strict constant time: the underlying
+ * libsecp256k1 curve operations are inherently variable-time, so this
+ * function does not protect against attackers that can observe
+ * microarchitectural variation of individual point operations. In shared /
+ * multitenant deployments where such attacks are relevant, callers should
+ * not expose decryption latency to untrusted observers.
  *
  * Architectural note: on-chain validators and verifiers never decrypt
  * ciphertexts; this function is intended for testing and basic client-
- * side operations.  Off-chain applications (wallets, audit tooling) that
+ * side operations. Off-chain applications (wallets, audit tooling) that
  * need to decrypt larger balances should use more efficient discrete
  * logarithm algorithms such as baby-step giant-step (O(sqrt(n))) or
  * Pollard's kangaroo.
  *
- * @return 1 if the ciphertext decrypts to an amount in [0, 1,000,000]
- *         and `*amount` is set; 0 otherwise.  A 0 return covers both
+ * @param[in]  ctx        A pointer to a valid secp256k1 context.
+ * @param[out] amount     Set to the decrypted plaintext amount on success.
+ * @param[in]  c1         The C1 component of the ElGamal ciphertext.
+ * @param[in]  c2         The C2 component of the ElGamal ciphertext.
+ * @param[in]  privkey    The 32-byte ElGamal private key.
+ * @param[in]  range_low  Lower bound of the search range (inclusive).
+ * @param[in]  range_high Upper bound of the search range (inclusive).
+ *                        Must be >= range_low; returns 0 otherwise.
+ *                        Recommended default: range_low=0, range_high=1000000.
+ *
+ * @return 1 if the ciphertext decrypts to an amount in [range_low, range_high]
+ *         and `*amount` is set; 0 otherwise. A 0 return covers both
  *         "amount out of range" and "internal failure".
  */
 SECP256K1_API int
@@ -68,7 +77,9 @@ secp256k1_elgamal_decrypt(
     uint64_t* amount,
     secp256k1_pubkey const* c1,
     secp256k1_pubkey const* c2,
-    unsigned char const* privkey);
+    unsigned char const* privkey,
+    uint64_t range_low,
+    uint64_t range_high);
 
 /**
  * @brief Homomorphically adds two ElGamal ciphertexts.

--- a/include/utility/mpt_utility.h
+++ b/include/utility/mpt_utility.h
@@ -174,7 +174,11 @@ mpt_encrypt_amount(
  * @param ciphertext [in]  A 66-byte buffer containing the two points (C1, C2).
  * @param privkey    [in]  The 32-byte private key.
  * @param out_amount [out] Pointer to store the decrypted uint64_t amount.
- * @return 0 on success, -1 on failure.
+ * @param range_low  [in]  Lower bound of the search range (inclusive).
+ * @param range_high [in]  Upper bound of the search range (inclusive).
+ * @return 0 on success, -1 on failure, -2 if range_low > range_high.
+ * @note Performance scales linearly with (range_high - range_low). A range of [0, 1,000,000] takes
+ * approximately 3 seconds on Apple Silicon. Do not pass arbitrarily large ranges.
  */
 int
 mpt_decrypt_amount(

--- a/include/utility/mpt_utility.h
+++ b/include/utility/mpt_utility.h
@@ -180,7 +180,9 @@ int
 mpt_decrypt_amount(
     uint8_t const ciphertext[kMPT_ELGAMAL_TOTAL_SIZE],
     uint8_t const privkey[kMPT_PRIVKEY_SIZE],
-    uint64_t* out_amount);
+    uint64_t* out_amount,
+    uint64_t range_low,
+    uint64_t range_high);
 
 /* ============================================================================
  * ZKProof Generation

--- a/src/elgamal.c
+++ b/src/elgamal.c
@@ -112,20 +112,14 @@ int secp256k1_elgamal_encrypt(const secp256k1_context *ctx,
 
 /* --- Decryption --- */
 
-/* Maximum recoverable plaintext for the linear DLP search.  Documented in
- * the public header (secp256k1_mpt.h, doxygen on secp256k1_elgamal_decrypt).
- * Off-chain callers requiring larger ranges should switch to BSGS or
- * Pollard's kangaroo. */
-#define MPT_ELGAMAL_DECRYPT_MAX_RANGE ((uint64_t)2000)
-
-/* Branchless brute-force DLP solver over the range [1, max_range].
+/* Branchless brute-force DLP solver over the range [range_low, range_high].
  *
- * Runs exactly `max_range` iterations regardless of whether and where the
- * target is found.  This is a "fixed iteration count" property, not a
- * full constant-time guarantee: the underlying libsecp256k1 EC operations
- * are themselves variable-time, so this loop hides the position of the
- * match but not microarchitectural variations of individual point ops.
- * The public-API doxygen documents this caveat.
+ * Runs exactly `range_high - effective_low + 1` iterations regardless of
+ * whether and where the target is found, where effective_low = max(1,
+ * range_low). This is a "fixed iteration count" property, not a full
+ * constant-time guarantee: the underlying libsecp256k1 EC operations are
+ * themselves variable-time, so this loop hides the position of the match but
+ * not microarchitectural variations of individual point ops.
  *
  * On success, `*out_amount` holds the recovered `i` such that `i*G`
  * serializes to `target_ser`, and `*out_is_found` is 1; if no match is
@@ -133,9 +127,13 @@ int secp256k1_elgamal_encrypt(const secp256k1_context *ctx,
  * libsecp256k1 serialization fail). */
 static int secp256k1_solve_dlp_small_range_fixed(
     const secp256k1_context *ctx, uint64_t *out_amount, uint64_t *out_is_found,
-    const unsigned char target_ser[33], uint64_t max_range)
+    const unsigned char target_ser[33], uint64_t range_low, uint64_t range_high)
 {
-  if (max_range == 0)
+  /* The zero case (m=0) is handled separately by the caller.
+   * Effective start for this loop is max(1, range_low). */
+  uint64_t effective_low = (range_low < 1) ? 1 : range_low;
+
+  if (effective_low > range_high)
   {
     *out_amount = 0;
     *out_is_found = 0;
@@ -152,7 +150,33 @@ static int secp256k1_solve_dlp_small_range_fixed(
     return 0;
   }
 
-  secp256k1_pubkey current_M = G_point; /* start at 1*G */
+  /* Compute starting point: effective_low * G.
+   * If effective_low == 1, this is just G_point.
+   * Otherwise, encode effective_low as a 32-byte big-endian scalar and
+   * compute the starting point via scalar multiplication. */
+  secp256k1_pubkey current_M;
+  if (effective_low == 1)
+  {
+    current_M = G_point;
+  }
+  else
+  {
+    unsigned char start_scalar[kMPT_SCALAR_SIZE] = {0};
+    uint64_t tmp = effective_low;
+    for (int k = 0; k < 8; k++)
+    {
+      start_scalar[kMPT_SCALAR_SIZE - 1 - k] = (unsigned char)(tmp & 0xFF);
+      tmp >>= 8;
+    }
+    int ok = secp256k1_ec_pubkey_create(ctx, &current_M, start_scalar);
+    OPENSSL_cleanse(start_scalar, kMPT_SCALAR_SIZE);
+    if (!ok)
+    {
+      OPENSSL_cleanse(one, kMPT_SCALAR_SIZE);
+      return 0;
+    }
+  }
+
   secp256k1_pubkey next_M;
   const secp256k1_pubkey *pts[2];
   unsigned char current_M_ser[33];
@@ -161,7 +185,7 @@ static int secp256k1_solve_dlp_small_range_fixed(
   uint64_t is_found = 0;
   unsigned char global_ser_error = 0;
 
-  for (uint64_t i = 1; i <= max_range; ++i)
+  for (uint64_t i = effective_low; i <= range_high; ++i)
   {
     /* Serialize current_M.  Use a fallback buffer so a libsecp failure
      * cannot leak data through the comparison below. */
@@ -194,10 +218,7 @@ static int secp256k1_solve_dlp_small_range_fixed(
     uint64_t match = 1 ^ (((diff64 | (~diff64 + 1)) >> 63) & 1);
 
     /* Constant-time conditional move: when `match` is 1, overwrite
-     * `found_amount` with `i`; otherwise leave it unchanged.  At most
-     * one iteration can match because G has prime order and i ranges
-     * over [1, max_range] << ord(G), so each `i*G` is distinct; no
-     * "stick on first match" guard is needed. */
+     * `found_amount` with `i`; otherwise leave it unchanged. */
     uint64_t match_mask = ~(match - 1);
     found_amount ^= (found_amount ^ i) & match_mask;
     is_found |= match;
@@ -213,8 +234,6 @@ static int secp256k1_solve_dlp_small_range_fixed(
       curr_ptr[b] =
           (curr_ptr[b] & ~combine_mask) | (next_ptr[b] & combine_mask);
 
-    /* Combine failures are tracked the same way as serialization failures
-     * so we don't leak via the loop trip count. */
     global_ser_error |= (unsigned char)(combine_ok ^ 1);
   }
 
@@ -236,13 +255,18 @@ static int secp256k1_solve_dlp_small_range_fixed(
 int secp256k1_elgamal_decrypt(const secp256k1_context *ctx, uint64_t *amount,
                               const secp256k1_pubkey *c1,
                               const secp256k1_pubkey *c2,
-                              const unsigned char *privkey)
+                              const unsigned char *privkey, uint64_t range_low,
+                              uint64_t range_high)
 {
   MPT_ARG_CHECK(ctx != NULL);
   MPT_ARG_CHECK(amount != NULL);
   MPT_ARG_CHECK(c1 != NULL);
   MPT_ARG_CHECK(c2 != NULL);
   MPT_ARG_CHECK(privkey != NULL);
+
+  /* Validate range */
+  if (range_low > range_high)
+    return 0;
 
   secp256k1_pubkey S, M_target_sum, neg_S;
   const secp256k1_pubkey *pts[2];
@@ -279,6 +303,10 @@ int secp256k1_elgamal_decrypt(const secp256k1_context *ctx, uint64_t *amount,
   uint64_t zero_diff64 = (uint64_t)zero_diff_u8;
   uint64_t match_zero = 1 ^ (((zero_diff64 | (~zero_diff64 + 1)) >> 63) & 1);
 
+  /* Only accept zero match if 0 is within [range_low, range_high]. */
+  uint64_t zero_in_range = (range_low == 0) ? (uint64_t)1 : (uint64_t)0;
+  uint64_t effective_match_zero = match_zero & (~(zero_in_range - 1));
+
   /* 3. Compute M_target_sum = c2 - S = c2 + (-S).  If this fails (point
    * at infinity, which is exactly the m=0 case), we leave M_target_ser
    * as the constant zero buffer so the loop simply never matches. */
@@ -303,16 +331,15 @@ int secp256k1_elgamal_decrypt(const secp256k1_context *ctx, uint64_t *amount,
     OPENSSL_cleanse(tmp, 33);
   }
 
-  /* 4. Fixed-iteration DLP search. */
+  /* 4. Fixed-iteration DLP search over [range_low, range_high]. */
   uint64_t loop_amount = 0;
   uint64_t match_loop = 0;
   int solver_ok = secp256k1_solve_dlp_small_range_fixed(
-      ctx, &loop_amount, &match_loop, M_target_ser,
-      MPT_ELGAMAL_DECRYPT_MAX_RANGE);
+      ctx, &loop_amount, &match_loop, M_target_ser, range_low, range_high);
 
   /* 5. Constant-time resolution: prefer the m=0 path if it matched. */
-  uint64_t is_found = match_zero | match_loop;
-  uint64_t zero_mask = ~(match_zero - 1);
+  uint64_t is_found = effective_match_zero | match_loop;
+  uint64_t zero_mask = ~(effective_match_zero - 1);
   *amount = (loop_amount & ~zero_mask); /* loop_amount when match_zero=0 */
   /* zero_mask=all-ones if match_zero=1 — *amount stays 0 in that case. */
 
@@ -430,10 +457,7 @@ int generate_canonical_encrypted_zero(
 
   /* Rejection sampling: chain-hash the 32-byte previous output until it is a
    * valid secp256k1 scalar. The probability of needing more than one iteration
-   * is ~2^-128, so in practice the loop body executes zero times. The chain
-   * deliberately hashes only the previous output (not the full 51-byte
-   * domain-tagged buffer): mixing stale tail bytes from `hash_input` would
-   * yield a non-standard construction without any security benefit. */
+   * is ~2^-128, so in practice the loop body executes zero times. */
   while (!secp256k1_ec_seckey_verify(ctx, deterministic_scalar))
   {
     if (EVP_Digest(deterministic_scalar, kMPT_HALF_SHA_SIZE,
@@ -444,7 +468,7 @@ int generate_canonical_encrypted_zero(
   ret = secp256k1_elgamal_encrypt(ctx, enc_zero_c1, enc_zero_c2, pubkey, 0,
                                   deterministic_scalar);
 
-  OPENSSL_cleanse(deterministic_scalar, kMPT_SCALAR_SIZE); // Secure cleanup
+  OPENSSL_cleanse(deterministic_scalar, kMPT_SCALAR_SIZE);
   return ret;
 }
 

--- a/src/utility/mpt_utility.cpp
+++ b/src/utility/mpt_utility.cpp
@@ -504,6 +504,8 @@ mpt_decrypt_amount(
 {
     if (!in_ciphertext || !privkey || !out_amount)
         return -1;
+    if (range_low > range_high)
+        return -2;
 
     secp256k1_context const* ctx = mpt_secp256k1_context();
     if (!ctx)

--- a/src/utility/mpt_utility.cpp
+++ b/src/utility/mpt_utility.cpp
@@ -498,7 +498,9 @@ int
 mpt_decrypt_amount(
     uint8_t const in_ciphertext[kMPT_ELGAMAL_TOTAL_SIZE],
     uint8_t const privkey[kMPT_PRIVKEY_SIZE],
-    uint64_t* out_amount)
+    uint64_t* out_amount,
+    uint64_t range_low,
+    uint64_t range_high)
 {
     if (!in_ciphertext || !privkey || !out_amount)
         return -1;
@@ -511,7 +513,7 @@ mpt_decrypt_amount(
     if (!mpt_make_ec_pair(in_ciphertext, &c1, &c2))
         return -1;
 
-    if (secp256k1_elgamal_decrypt(ctx, out_amount, &c1, &c2, privkey) != 1)
+    if (secp256k1_elgamal_decrypt(ctx, out_amount, &c1, &c2, privkey, range_low, range_high) != 1)
         return -1;
 
     return 0;

--- a/tests/test_elgamal.c
+++ b/tests/test_elgamal.c
@@ -57,7 +57,6 @@ static void test_encryption(const secp256k1_context *ctx)
   secp256k1_pubkey pubkey, c1, c2, temp_pubkey;
   printf("Running test: secp256k1_elgamal_encrypt (smoke test)...\n");
   EXPECT(secp256k1_elgamal_generate_keypair(ctx, privkey, &pubkey) == 1);
-  // Note: Reusing generate_keypair is a convenient way to get a random scalar
   EXPECT(secp256k1_elgamal_generate_keypair(ctx, blinding_factor,
                                             &temp_pubkey) == 1);
   EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 12345,
@@ -77,8 +76,8 @@ static void test_encryption_decryption_roundtrip(const secp256k1_context *ctx)
                                             &temp_pubkey) == 1);
   EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, original_amount,
                                    blinding_factor) == 1);
-  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey) ==
-         1);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey, 0,
+                                   2000) == 1);
   EXPECT(original_amount == decrypted_amount);
   printf("Test passed!\n");
 }
@@ -112,13 +111,13 @@ static void test_homomorphic_operations(const secp256k1_context *ctx)
   EXPECT(secp256k1_elgamal_add(ctx, &result_c1, &result_c2, &a_c1, &a_c2, &b_c1,
                                &b_c2) == 1);
   EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_result, &result_c1,
-                                   &result_c2, privkey) == 1);
+                                   &result_c2, privkey, 0, 2000) == 1);
   EXPECT(decrypted_result == amount_a + amount_b);
 
   EXPECT(secp256k1_elgamal_subtract(ctx, &result_c1, &result_c2, &a_c1, &a_c2,
                                     &b_c1, &b_c2) == 1);
   EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_result, &result_c1,
-                                   &result_c2, privkey) == 1);
+                                   &result_c2, privkey, 0, 2000) == 1);
   EXPECT(decrypted_result == amount_a - amount_b);
   printf("Test passed!\n");
 }
@@ -128,15 +127,15 @@ static void test_zero_encryption(const secp256k1_context *ctx)
   unsigned char privkey[32], blinding_factor[32];
   secp256k1_pubkey pubkey, c1, c2, temp_pubkey;
   uint64_t original_amount = 0;
-  uint64_t decrypted_amount = 999; // Non-zero initial value
+  uint64_t decrypted_amount = 999;
   printf("Running test: encrypting a random zero...\n");
   EXPECT(secp256k1_elgamal_generate_keypair(ctx, privkey, &pubkey) == 1);
   EXPECT(secp256k1_elgamal_generate_keypair(ctx, blinding_factor,
                                             &temp_pubkey) == 1);
   EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, original_amount,
                                    blinding_factor) == 1);
-  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey) ==
-         1);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey, 0,
+                                   2000) == 1);
   EXPECT(original_amount == decrypted_amount);
   printf("Test passed!\n");
 }
@@ -148,29 +147,23 @@ static void test_canonical_zero(const secp256k1_context *ctx)
   secp256k1_pubkey c1_a, c2_a, c1_b, c2_b;
   uint64_t decrypted_amount = 999;
 
-  // Use placeholder byte arrays for IDs (20 bytes for account, 24 for issuance)
-  unsigned char account_id[20] = {1};  // Example ID
-  unsigned char issuance_id[24] = {2}; // Example ID
+  unsigned char account_id[20] = {1};
+  unsigned char issuance_id[24] = {2};
 
   printf("Running test: canonical encrypted zero...\n");
   EXPECT(secp256k1_elgamal_generate_keypair(ctx, privkey, &pubkey) == 1);
 
-  // Generate it once
   EXPECT(generate_canonical_encrypted_zero(ctx, &c1_a, &c2_a, &pubkey,
                                            account_id, issuance_id) == 1);
-
-  // Generate it a second time with the same inputs
   EXPECT(generate_canonical_encrypted_zero(ctx, &c1_b, &c2_b, &pubkey,
                                            account_id, issuance_id) == 1);
 
-  // 1. Verify that it decrypts to zero
+  /* 1. Verify that it decrypts to zero */
   EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1_a, &c2_a,
-                                   privkey) == 1);
+                                   privkey, 0, 2000) == 1);
   EXPECT(decrypted_amount == 0);
 
-  // 2. Verify that the output is deterministic (both ciphertexts are identical)
-  //    We compare the internal structs directly for this test, assuming
-  //    determinism holds internally.
+  /* 2. Verify determinism */
   EXPECT(memcmp(&c1_a, &c1_b, sizeof(c1_a)) == 0);
   EXPECT(memcmp(&c2_a, &c2_b, sizeof(c2_a)) == 0);
 
@@ -195,7 +188,7 @@ static void test_verify_encryption(const secp256k1_context *ctx)
   EXPECT(secp256k1_elgamal_verify_encryption(ctx, &c1, &c2, &pubkey, amount,
                                              blinding_factor) == 1);
 
-  /* 2. Test zero-value encryption verification (The special case we added) */
+  /* 2. Test zero-value encryption verification */
   EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, zero_amount,
                                    blinding_factor) == 1);
   EXPECT(secp256k1_elgamal_verify_encryption(
@@ -206,57 +199,94 @@ static void test_verify_encryption(const secp256k1_context *ctx)
                                              blinding_factor) == 0);
 
   /* 4. Test detection of tampered ciphertext */
-  c2 = c1; // Force a mismatch
+  c2 = c1;
   EXPECT(secp256k1_elgamal_verify_encryption(
              ctx, &c1, &c2, &pubkey, zero_amount, blinding_factor) == 0);
 
   printf("Test passed!\n");
 }
+
 static void test_decryption_boundaries(const secp256k1_context *ctx)
 {
   unsigned char privkey[32], blinding_factor[32];
   secp256k1_pubkey pubkey, c1, c2, temp_pubkey;
   uint64_t decrypted_amount = 0;
 
-  printf("Running test: decryption boundary limits (0, 1, 2000, 2001)...\n");
+  printf("Running test: decryption boundary limits with [range_low, "
+         "range_high]...\n");
   EXPECT(secp256k1_elgamal_generate_keypair(ctx, privkey, &pubkey) == 1);
-
-  // Need a random scalar for the blinding factor
   EXPECT(secp256k1_elgamal_generate_keypair(ctx, blinding_factor,
                                             &temp_pubkey) == 1);
 
-  /* amount = 0: exercises the c2 == S fast-path in the constant-time
-   * branchless arithmetic.  Must decrypt to exactly 0. */
+  /* --- Default range [0, 2000] tests --- */
+
+  /* amount = 0: must succeed with range [0, 2000]. */
   decrypted_amount = 0xDEADBEEFu;
   EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 0,
                                    blinding_factor) == 1);
-  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey) ==
-         1);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey, 0,
+                                   2000) == 1);
   EXPECT(decrypted_amount == 0);
 
-  /* amount = 1: smallest positive value; first DLP iteration matches. */
+  /* amount = 1: smallest positive value. */
   decrypted_amount = 0xDEADBEEFu;
   EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 1,
                                    blinding_factor) == 1);
-  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey) ==
-         1);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey, 0,
+                                   2000) == 1);
   EXPECT(decrypted_amount == 1);
 
-  /* Exact upper boundary: 2,000.  Must succeed; the fixed-iteration
-   * loop runs to completion and the last iteration matches. */
+  /* amount = 2000: exact upper boundary with [0, 2000]. */
   decrypted_amount = 0xDEADBEEFu;
   EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 2000,
                                    blinding_factor) == 1);
-  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey) ==
-         1);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey, 0,
+                                   2000) == 1);
   EXPECT(decrypted_amount == 2000);
 
-  /* Just outside the boundary: 2,001.  Decrypt must gracefully fail
-   * (return 0) without producing a stale `decrypted_amount`. */
+  /* amount = 2001: just outside [0, 2000], must fail. */
   EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 2001,
                                    blinding_factor) == 1);
-  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey) ==
-         0);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey, 0,
+                                   2000) == 0);
+
+  /* --- Custom range [500, 1500] tests --- */
+
+  /* amount = 1000: within [500, 1500], must succeed. */
+  decrypted_amount = 0xDEADBEEFu;
+  EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 1000,
+                                   blinding_factor) == 1);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey,
+                                   500, 1500) == 1);
+  EXPECT(decrypted_amount == 1000);
+
+  /* amount = 200: below [500, 1500], must fail. */
+  EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 200,
+                                   blinding_factor) == 1);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey,
+                                   500, 1500) == 0);
+
+  /* amount = 2000: above [500, 1500], must fail. */
+  EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 2000,
+                                   blinding_factor) == 1);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey,
+                                   500, 1500) == 0);
+
+  /* --- Invalid range test --- */
+
+  /* range_low > range_high: must fail immediately. */
+  EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 100,
+                                   blinding_factor) == 1);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey,
+                                   1000, 500) == 0);
+
+  /* --- Zero exclusion test --- */
+
+  /* amount = 0 with range_low > 0: must fail (zero excluded from range). */
+  EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 0,
+                                   blinding_factor) == 1);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey, 1,
+                                   2000) == 0);
 
   printf("Test passed!\n");
 }

--- a/tests/test_mpt_utility.cpp
+++ b/tests/test_mpt_utility.cpp
@@ -162,8 +162,8 @@ test_encryption_decryption_integrate()
         0,
         1,
         1000,
-        // todo: due to the lib's current limitation, large numbers
-        // are not supported yet. We need to add them back once the limitation is fixed.
+        // Large amounts are omitted for test performance. With BSGS these
+        // will be fast and can be re-enabled.
         // 123456789,
         // 10000000000ULL
     };
@@ -174,7 +174,7 @@ test_encryption_decryption_integrate()
 
         EXPECT(mpt_generate_blinding_factor(bf) == 0);
         EXPECT(mpt_encrypt_amount(original_amount, pub, bf, ciphertext) == 0);
-        EXPECT(mpt_decrypt_amount(ciphertext, priv, &decrypted_amount) == 0);
+        EXPECT(mpt_decrypt_amount(ciphertext, priv, &decrypted_amount, 0, 2000) == 0);
         EXPECT(decrypted_amount == original_amount);
     }
 }


### PR DESCRIPTION
Summary
Replaces the hardcoded MPT_ELGAMAL_DECRYPT_MAX_RANGE constant with a configurable [range_low, range_high] parameter pair in secp256k1_elgamal_decrypt and mpt_decrypt_amount. This allows callers to specify the decryption range at call time rather than compile time.

Changes

- Removed hardcoded #define MPT_ELGAMAL_DECRYPT_MAX_RANGE
- Updated secp256k1_solve_dlp_small_range_fixed to accept range_low and range_high — computes the starting point range_low * G via scalar multiplication when range_low > 1
- Updated secp256k1_elgamal_decrypt to accept and validate range_low and range_high, suppresses zero match if range_low > 0
- Updated mpt_decrypt_amount to accept and pass through range_low and range_high

tests/test_elgamal.c

- Updated all decrypt calls to pass explicit range parameters
- Expanded test_decryption_boundaries to cover default range, custom range [500, 1500], invalid range, and zero exclusion when range_low > 0

tests/test_mpt_utility.cpp

- Updated mpt_decrypt_amount call site to pass [0, 2000]
- Updated TODO comments to reflect parametrized approach


Notes

- The constant-time fixed-iteration property is preserved within the specified [range_low, range_high] interval
- Zero (m=0) is handled separately and is only accepted if range_low == 0
- BSGS integration will follow in a subsequent PR after internal and external review