### PR TITLE
fix(scalar): change secp256k1_mpt_scalar_inverse to return int and reject zero input

### DIFF
--- a/include/secp256k1_mpt.h
+++ b/include/secp256k1_mpt.h
@@ -248,7 +248,11 @@ void
 secp256k1_mpt_scalar_add(unsigned char* res, unsigned char const* a, unsigned char const* b);
 void
 secp256k1_mpt_scalar_mul(unsigned char* res, unsigned char const* a, unsigned char const* b);
-void
+/* Computes the modular inverse of a scalar. Returns 1 on success,
+ * 0 if the input is zero (inverse undefined). Callers must check
+ * the return value. */
+
+int
 secp256k1_mpt_scalar_inverse(unsigned char* res, unsigned char const* in);
 void
 secp256k1_mpt_scalar_negate(unsigned char* res, unsigned char const* in);

--- a/src/bulletproof_aggregated.c
+++ b/src/bulletproof_aggregated.c
@@ -931,7 +931,8 @@ int secp256k1_bulletproof_run_ipa_prover(
       goto cleanup;
 
     /* 4) u_r^{-1} */
-    secp256k1_mpt_scalar_inverse(u_inv, u_scalar);
+    if (!secp256k1_mpt_scalar_inverse(u_inv, u_scalar))
+      goto cleanup;
     if (!secp256k1_ec_seckey_verify(ctx, u_inv))
       goto cleanup;
 
@@ -1028,7 +1029,8 @@ static int ipa_verify_explicit(
     if (!derive_ipa_round_challenge(ctx, ui, last, &L_vec[i], &R_vec[i]))
       goto cleanup;
 
-    secp256k1_mpt_scalar_inverse(uiinv, ui);
+    if (!secp256k1_mpt_scalar_inverse(uiinv, ui))
+      goto cleanup;
     if (!secp256k1_ec_seckey_verify(ctx, uiinv))
       goto cleanup;
 
@@ -1996,7 +1998,8 @@ int secp256k1_bulletproof_prove_agg(
     if (memcmp(y, zero, kMPT_SCALAR_SIZE) == 0)
       goto cleanup;
 
-    secp256k1_mpt_scalar_inverse(y_inv, y);
+    if (!secp256k1_mpt_scalar_inverse(y_inv, y))
+      goto cleanup;
     memcpy(y_inv_pow, one, kMPT_SCALAR_SIZE);
 
     for (size_t k = 0; k < n; k++)

--- a/src/mpt_scalar.c
+++ b/src/mpt_scalar.c
@@ -91,7 +91,7 @@ void secp256k1_mpt_scalar_mul(unsigned char *res, const unsigned char *a,
   OPENSSL_cleanse(&s_res, sizeof(s_res));
 }
 
-void secp256k1_mpt_scalar_inverse(unsigned char *res, const unsigned char *in)
+int secp256k1_mpt_scalar_inverse(unsigned char *res, const unsigned char *in)
 {
   secp256k1_scalar s;
   /* Overflow output discarded; see file-level @note. */
@@ -103,13 +103,14 @@ void secp256k1_mpt_scalar_inverse(unsigned char *res, const unsigned char *in)
   {
     memset(res, 0, 32);
     OPENSSL_cleanse(&s, sizeof(s));
-    return;
+    return 0;
   }
   secp256k1_scalar_inverse(&s, &s);
   secp256k1_scalar_get_b32(res, &s);
 
   /* SECURE CLEANUP */
   OPENSSL_cleanse(&s, sizeof(s));
+  return 1;
 }
 
 void secp256k1_mpt_scalar_negate(unsigned char *res, const unsigned char *in)


### PR DESCRIPTION
Summary
Addresses the remaining items from TOB-RIPCTXR-9 that were left partially resolved in PR #70.

Changes

- Changed secp256k1_mpt_scalar_inverse signature from void to int
- Returns 0 when the input scalar is zero (inverse is undefined)
- Returns 1 on success

include/secp256k1_mpt.h

- Updated declaration from void to int
- Added documentation comment explaining return values and zero input behaviour

src/bulletproof_aggregated.c

- Updated all 4 call sites to check the return value and goto cleanup or return 0 on failure
