### PR TITLE
fix(crypto): replace variable-time tweak_mul with constant-time wraper for secret scalars (TOB-RIPCTXR-11)

### DIFF
--- a/src/bulletproof_aggregated.c
+++ b/src/bulletproof_aggregated.c
@@ -203,7 +203,7 @@ int secp256k1_bulletproof_ipa_msm(const secp256k1_context *ctx,
     }
 
     secp256k1_pubkey term = points[i];
-    if (!secp256k1_ec_pubkey_tweak_mul(ctx, &term, s_tmp))
+    if (!mpt_ct_pubkey_tweak_mul(ctx, &term, s_tmp))
       return 0;
 
     if (!add_term(ctx, &acc, &initialized, &term))
@@ -535,7 +535,7 @@ int secp256k1_bulletproof_ipa_compute_LR(
   if (!scalar_is_zero(cLux))
   {
     term = *U;
-    if (!secp256k1_ec_pubkey_tweak_mul(ctx, &term, cLux))
+    if (!mpt_ct_pubkey_tweak_mul(ctx, &term, cLux))
       goto cleanup;
     if (!add_term(ctx, &acc, &acc_inited, &term))
       goto cleanup;
@@ -562,7 +562,7 @@ int secp256k1_bulletproof_ipa_compute_LR(
   if (!scalar_is_zero(cRux))
   {
     term = *U;
-    if (!secp256k1_ec_pubkey_tweak_mul(ctx, &term, cRux))
+    if (!mpt_ct_pubkey_tweak_mul(ctx, &term, cRux))
       goto cleanup;
     if (!add_term(ctx, &acc, &acc_inited, &term))
       goto cleanup;
@@ -2570,7 +2570,7 @@ fs_fail:
     if (memcmp(tau_x, zero32, kMPT_SCALAR_SIZE) != 0)
     {
       tauH = *h_generator;
-      if (!secp256k1_ec_pubkey_tweak_mul(ctx, &tauH, tau_x))
+      if (!mpt_ct_pubkey_tweak_mul(ctx, &tauH, tau_x))
       {
         goto fail;
       }

--- a/src/commitments.c
+++ b/src/commitments.c
@@ -220,7 +220,7 @@ int secp256k1_mpt_pedersen_commit(const secp256k1_context *ctx,
     return 0;
 
   rH = H;
-  if (!secp256k1_ec_pubkey_tweak_mul(ctx, &rH, rho))
+  if (!mpt_ct_pubkey_tweak_mul(ctx, &rH, rho))
     return 0;
 
   /* 2. Handle Zero Amount Case */


### PR DESCRIPTION
## Summary

Addresses the remaining partially resolved items from TOB-RIPCTXR-11. PR #86 introduced `mpt_ct_pubkey_tweak_mul` and applied it to most secret scalar locations, but three locations were missed. This PR fixes those remaining cases.

## Changes

### `src/commitments.c`
- Line 223: `rho` (secret Pedersen blinding factor) — replaced `secp256k1_ec_pubkey_tweak_mul` with `mpt_ct_pubkey_tweak_mul`

### `src/bulletproof_aggregated.c`
- Line 206: `s_tmp` in `secp256k1_bulletproof_ipa_msm` — replaced with `mpt_ct_pubkey_tweak_mul`
- Line 538: `cLux` in `secp256k1_bulletproof_ipa_compute_LR` (prover only) — replaced with `mpt_ct_pubkey_tweak_mul`
- Line 565: `cRux` in `secp256k1_bulletproof_ipa_compute_LR` (prover only) — replaced with `mpt_ct_pubkey_tweak_mul`
- Line 2576: `tau_x` (secret Bulletproof blinding scalar) — replaced with `mpt_ct_pubkey_tweak_mul`
