### PR TITLE
fix(elgamal): prevent infinite loop when range_high = UINT64_MAX

### DIFF
--- a/include/secp256k1_mpt.h
+++ b/include/secp256k1_mpt.h
@@ -64,7 +64,13 @@ secp256k1_elgamal_encrypt(
  * @param[in]  privkey    The 32-byte ElGamal private key.
  * @param[in]  range_low  Lower bound of the search range (inclusive).
  * @param[in]  range_high Upper bound of the search range (inclusive).
- *                        Must be >= range_low; returns 0 otherwise.
+ *                        Must be >= range_low and must not be UINT64_MAX;
+ *                        either condition returns 0 immediately.  UINT64_MAX
+ *                        is rejected because the loop runs
+ *                        range_high - max(1, range_low) + 1 iterations — a
+ *                        UINT64_MAX upper bound would require up to 2^64 - 1
+ *                        iterations (effectively infinite).  Use
+ *                        secp256k1_elgamal_decrypt_bsgs for larger ranges.
  *                        Recommended default: range_low=0, range_high=1000000.
  *
  * @return 1 if the ciphertext decrypts to an amount in [range_low, range_high]

--- a/include/utility/mpt_utility.h
+++ b/include/utility/mpt_utility.h
@@ -176,7 +176,10 @@ mpt_encrypt_amount(
  * @param out_amount [out] Pointer to store the decrypted uint64_t amount.
  * @param range_low  [in]  Lower bound of the search range (inclusive).
  * @param range_high [in]  Upper bound of the search range (inclusive).
- * @return 0 on success, -1 on failure, -2 if range_low > range_high.
+ *                         Must satisfy range_low <= range_high and
+ *                         range_high != UINT64_MAX.
+ * @return 0 on success, -1 on failure, -2 if range_low > range_high or
+ *         range_high == UINT64_MAX.
  * @note Performance scales linearly with (range_high - range_low). A range of [0, 1,000,000] takes
  * approximately 3 seconds on Apple Silicon. Do not pass arbitrarily large ranges.
  */

--- a/src/elgamal.c
+++ b/src/elgamal.c
@@ -185,7 +185,12 @@ static int secp256k1_solve_dlp_small_range_fixed(
   uint64_t is_found = 0;
   unsigned char global_ser_error = 0;
 
-  for (uint64_t i = effective_low; i <= range_high; ++i)
+  /* Use a break-at-end loop so that range_high = UINT64_MAX does not cause
+   * unsigned wraparound (i++ from UINT64_MAX → 0, then 0 <= UINT64_MAX
+   * is always true → infinite loop).  Exactly range_high - effective_low + 1
+   * iterations are executed in all cases. */
+  uint64_t i = effective_low;
+  for (;;)
   {
     /* Serialize current_M.  Use a fallback buffer so a libsecp failure
      * cannot leak data through the comparison below. */
@@ -235,6 +240,10 @@ static int secp256k1_solve_dlp_small_range_fixed(
           (curr_ptr[b] & ~combine_mask) | (next_ptr[b] & combine_mask);
 
     global_ser_error |= (unsigned char)(combine_ok ^ 1);
+
+    if (i == range_high)
+      break;
+    ++i;
   }
 
   OPENSSL_cleanse(current_M_ser, 33);
@@ -264,8 +273,11 @@ int secp256k1_elgamal_decrypt(const secp256k1_context *ctx, uint64_t *amount,
   MPT_ARG_CHECK(c2 != NULL);
   MPT_ARG_CHECK(privkey != NULL);
 
-  /* Validate range */
-  if (range_low > range_high)
+  /* Validate range.  UINT64_MAX is rejected because the loop iterates
+   * range_high - effective_low + 1 times; a range_high of UINT64_MAX with
+   * effective_low >= 1 would require up to 2^64 - 1 iterations — effectively
+   * infinite.  Callers needing very large ranges should use BSGS. */
+  if (range_low > range_high || range_high == UINT64_MAX)
     return 0;
 
   secp256k1_pubkey S, M_target_sum, neg_S;

--- a/src/utility/mpt_utility.cpp
+++ b/src/utility/mpt_utility.cpp
@@ -519,7 +519,7 @@ mpt_decrypt_amount(
 {
     if (!in_ciphertext || !privkey || !out_amount)
         return -1;
-    if (range_low > range_high)
+    if (range_low > range_high || range_high == UINT64_MAX)
         return -2;
 
     secp256k1_context const* ctx = mpt_secp256k1_context();

--- a/tests/test_elgamal.c
+++ b/tests/test_elgamal.c
@@ -272,13 +272,20 @@ static void test_decryption_boundaries(const secp256k1_context *ctx)
   EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey,
                                    500, 1500) == 0);
 
-  /* --- Invalid range test --- */
+  /* --- Invalid range tests --- */
 
   /* range_low > range_high: must fail immediately. */
   EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 100,
                                    blinding_factor) == 1);
   EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey,
                                    1000, 500) == 0);
+
+  /* range_high == UINT64_MAX: must fail immediately (would be ~2^64 iterations
+   * and cause unsigned wraparound in the loop counter). */
+  EXPECT(secp256k1_elgamal_encrypt(ctx, &c1, &c2, &pubkey, 100,
+                                   blinding_factor) == 1);
+  EXPECT(secp256k1_elgamal_decrypt(ctx, &decrypted_amount, &c1, &c2, privkey, 0,
+                                   UINT64_MAX) == 0);
 
   /* --- Zero exclusion test --- */
 


### PR DESCRIPTION
## Summary

Addresses the Trail of Bits Slack finding: `secp256k1_solve_dlp_small_range_fixed` enters an infinite loop when `range_high = UINT64_MAX`.

**Root cause:** The loop continuation condition `i <= range_high` with `uint64_t i` wraps on `++i` from `UINT64_MAX` to 0, and `0 <= UINT64_MAX` is always true.

## Changes

- **`src/elgamal.c` (loop fix):** Restructured `secp256k1_solve_dlp_small_range_fixed` to use a break-at-end loop (`for (;;) { ...; if (i == range_high) break; ++i; }`). Iteration count is still exactly `range_high - effective_low + 1` with no unsigned wraparound in the condition.
- **`src/elgamal.c` (API guard):** `secp256k1_elgamal_decrypt` now rejects `range_high == UINT64_MAX` with `return 0` before calling the solver. A range of size ~2^64 would run for centuries; callers needing very large ranges should use BSGS.
- **`src/utility/mpt_utility.cpp`:** `mpt_decrypt_amount` similarly rejects `range_high == UINT64_MAX` with `-2` (same code as `range_low > range_high`).
- **`include/secp256k1_mpt.h` / `include/utility/mpt_utility.h`:** Doxygen updated to document the `UINT64_MAX` restriction and the `-2` return.
- **`tests/test_elgamal.c`:** Added regression test: encrypt amount 100, call `decrypt` with `range_high = UINT64_MAX`, assert return is 0 immediately.

## Test plan

- [ ] `./build-debug/tests/test_elgamal` passes (verified locally — all 8 test cases pass including new UINT64_MAX case)
- [ ] CI green