### PR TITLE
ci: Add workflow to build WASM artifact and attach to releases

### DIFF
--- a/.github/scripts/build-wasm.sh
+++ b/.github/scripts/build-wasm.sh
@@ -48,6 +48,21 @@ if [[ "${SECP256K1_VERSION}" == "v" || -z "${OPENSSL_VERSION}" ]]; then
     exit 1
 fi
 
+# Integrity pins for the directly-fetched sources. This WASM path fetches deps
+# outside Conan (git tag / release tarball), so verify them the way Conan does
+# from conan.lock. Update these together with the versions above.
+SECP256K1_COMMIT="1a53f4961f337b4d166c25fce72ef0dc88806618"                       # tag v0.7.1
+OPENSSL_SHA256="aaf51a1fe064384f811daeaeb4ec4dce7340ec8bd893027eee676af31e83a04f" # openssl-3.6.2.tar.gz
+
+# Portable sha256 (Linux coreutils sha256sum; macOS shasum).
+sha256_of() {
+    if command -v sha256sum &>/dev/null; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
 SECP256K1_SRC="${BUILD_DIR}/secp256k1"
 SECP256K1_BUILD="${BUILD_DIR}/secp256k1/build"
 OPENSSL_SRC="${BUILD_DIR}/openssl-${OPENSSL_VERSION}"
@@ -95,6 +110,14 @@ if [[ ! -f "${SECP256K1_BUILD}/lib/libsecp256k1.a" ]]; then
             https://github.com/bitcoin-core/secp256k1.git "${SECP256K1_SRC}"
     fi
 
+    # A git tag is mutable (can be force-pushed); the commit it resolves to is
+    # not. Verify the checked-out commit against the pin.
+    actual_sha="$(git -C "${SECP256K1_SRC}" rev-parse HEAD)"
+    if [[ "${actual_sha}" != "${SECP256K1_COMMIT}" ]]; then
+        echo "ERROR: secp256k1 ${SECP256K1_VERSION} is ${actual_sha}, expected ${SECP256K1_COMMIT}" >&2
+        exit 1
+    fi
+
     mkdir -p "${SECP256K1_BUILD}"
     cd "${SECP256K1_BUILD}"
 
@@ -131,8 +154,16 @@ if [[ ! -f "${OPENSSL_SRC}/libcrypto.a" ]]; then
 
     if [[ ! -d "${OPENSSL_SRC}" ]]; then
         cd "${BUILD_DIR}"
-        curl -sL "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" \
-            | tar xz
+        openssl_tarball="openssl-${OPENSSL_VERSION}.tar.gz"
+        curl -sL "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/${openssl_tarball}" \
+            -o "${openssl_tarball}"
+        got="$(sha256_of "${openssl_tarball}")"
+        if [[ "${got}" != "${OPENSSL_SHA256}" ]]; then
+            echo "ERROR: ${openssl_tarball} sha256 ${got}, expected ${OPENSSL_SHA256}" >&2
+            exit 1
+        fi
+        tar xzf "${openssl_tarball}"
+        rm -f "${openssl_tarball}"
         cd "${ROOT_DIR}"
     fi
 

--- a/.github/scripts/build-wasm.sh
+++ b/.github/scripts/build-wasm.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# build-wasm.sh — Build the shipped mpt-crypto WebAssembly module.
+#
+# Produces the single JS-consumable artifact that downstream JS/TS libraries
+# (e.g. xrpl.js) vendor:
+#   emcc_out/mpt_crypto.js    (Emscripten MODULARIZE glue / loader)
+#   emcc_out/mpt_crypto.wasm  (the compiled module, curated exports)
+#
+# Builds ONLY the module (not tests) — the companion test-wasm.sh validates it
+# by running the crypto suite under Node; the CI workflow runs both in order.
+# It has a dedicated emcc link (rather than CMake, like the native shared lib)
+# because the wasm module needs MODULARIZE/exports/WASM_BIGINT.
+#
+# As a side effect it builds the wasm-target secp256k1 + OpenSSL static libs
+# into emcc_build/, which test-wasm.sh reuses.
+#
+# Prerequisites: Emscripten SDK (emcc, em++, emcmake, emmake) on PATH.
+#
+# Usage (paths resolve to the repo root, so run from anywhere):
+#   ./.github/scripts/build-wasm.sh          # full build (deps + module)
+#   ./.github/scripts/build-wasm.sh --clean  # remove build artifacts and rebuild
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+BUILD_DIR="${ROOT_DIR}/emcc_build"
+OUT_DIR="${ROOT_DIR}/emcc_out"
+CONAN_LOCK="${ROOT_DIR}/conan.lock"
+
+# Pin dependency versions to conan.lock so this WASM build always matches the
+# Conan package rippled consumes — drift here can silently break proof interop.
+# secp256k1 drives the curve math (version-critical); OpenSSL is only SHA-2 +
+# RAND, but we track it too to avoid surprises.
+if [[ ! -f "${CONAN_LOCK}" ]]; then
+    echo "ERROR: ${CONAN_LOCK} not found" >&2
+    exit 1
+fi
+lock_version() {
+    sed -nE "s|.*\"$1/([0-9][^#\"]*)#.*|\1|p" "${CONAN_LOCK}" | head -n1
+}
+
+# secp256k1's git tag is "v0.7.1"; conan.lock stores "0.7.1", so prefix "v".
+SECP256K1_VERSION="v$(lock_version secp256k1)"
+OPENSSL_VERSION="$(lock_version openssl)"
+
+if [[ "${SECP256K1_VERSION}" == "v" || -z "${OPENSSL_VERSION}" ]]; then
+    echo "ERROR: could not read secp256k1/openssl versions from ${CONAN_LOCK}" >&2
+    exit 1
+fi
+
+SECP256K1_SRC="${BUILD_DIR}/secp256k1"
+SECP256K1_BUILD="${BUILD_DIR}/secp256k1/build"
+OPENSSL_SRC="${BUILD_DIR}/openssl-${OPENSSL_VERSION}"
+OBJ_DIR="${BUILD_DIR}/obj"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log() { echo "==> $*"; }
+require_cmd() {
+    if ! command -v "$1" &>/dev/null; then
+        echo "ERROR: $1 not found. Install Emscripten SDK and add to PATH." >&2
+        exit 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Argument handling
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--clean" ]]; then
+    log "Cleaning build artifacts"
+    rm -rf "${BUILD_DIR}" "${OUT_DIR}"
+fi
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+require_cmd emcc
+require_cmd em++
+require_cmd emcmake
+require_cmd emmake
+
+mkdir -p "${BUILD_DIR}" "${OUT_DIR}" "${OBJ_DIR}"
+
+log "Dependencies (from conan.lock): secp256k1 ${SECP256K1_VERSION}, openssl ${OPENSSL_VERSION}"
+
+# ---------------------------------------------------------------------------
+# 1. Build secp256k1
+# ---------------------------------------------------------------------------
+if [[ ! -f "${SECP256K1_BUILD}/lib/libsecp256k1.a" ]]; then
+    log "Building secp256k1 ${SECP256K1_VERSION}"
+
+    if [[ ! -d "${SECP256K1_SRC}/CMakeLists.txt" ]]; then
+        git clone --depth 1 --branch "${SECP256K1_VERSION}" \
+            https://github.com/bitcoin-core/secp256k1.git "${SECP256K1_SRC}" 2>/dev/null || true
+    fi
+
+    mkdir -p "${SECP256K1_BUILD}"
+    cd "${SECP256K1_BUILD}"
+
+    emcmake cmake .. \
+        -DCMAKE_C_FLAGS="-DSECP256K1_WIDEMUL_INT64" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DSECP256K1_BUILD_TESTS=OFF \
+        -DSECP256K1_BUILD_BENCHMARK=OFF \
+        -DSECP256K1_BUILD_CTIME_TESTS=OFF \
+        -DSECP256K1_BUILD_EXAMPLES=OFF \
+        -DSECP256K1_ENABLE_MODULE_ECDH=ON \
+        -DSECP256K1_ENABLE_MODULE_RECOVERY=OFF \
+        -DSECP256K1_ENABLE_MODULE_EXTRAKEYS=OFF \
+        -DSECP256K1_ENABLE_MODULE_SCHNORRSIG=OFF \
+        -DSECP256K1_ENABLE_MODULE_MUSIG=OFF \
+        -DSECP256K1_ENABLE_MODULE_ELLSWIFT=OFF \
+        -DSECP256K1_ECMULT_WINDOW_SIZE=15 \
+        -DSECP256K1_ECMULT_GEN_KB=86
+
+    emmake make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+
+    cd "${ROOT_DIR}"
+    log "secp256k1 built: $(wc -c < "${SECP256K1_BUILD}/lib/libsecp256k1.a") bytes"
+else
+    log "secp256k1 already built — skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Build OpenSSL (stripped for SHA-256/512 + RAND_bytes only)
+# ---------------------------------------------------------------------------
+if [[ ! -f "${OPENSSL_SRC}/libcrypto.a" ]]; then
+    log "Building OpenSSL ${OPENSSL_VERSION}"
+
+    if [[ ! -d "${OPENSSL_SRC}" ]]; then
+        cd "${BUILD_DIR}"
+        curl -sL "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/openssl-${OPENSSL_VERSION}.tar.gz" \
+            | tar xz
+        cd "${ROOT_DIR}"
+    fi
+
+    cd "${OPENSSL_SRC}"
+
+    # Heavily stripped configure — only SHA-256, SHA-512, RAND_bytes, OPENSSL_cleanse
+    perl Configure linux-generic32 \
+        --cross-compile-prefix= \
+        CC=emcc AR=emar RANLIB=emranlib \
+        no-asm no-threads no-shared no-dso no-engine no-async \
+        no-ssl no-tls no-dtls no-cms no-comp no-ct no-ts no-srp no-srtp \
+        no-ocsp no-cmp no-fips no-legacy no-tests no-ui-console no-stdio \
+        no-err no-autoerrinit no-autoalginit \
+        no-des no-rc2 no-rc4 no-idea no-seed no-bf no-cast no-camellia no-aria \
+        no-sm2 no-sm3 no-sm4 no-whirlpool no-rmd160 no-mdc2 no-blake2 \
+        no-siphash no-poly1305 no-chacha \
+        no-dh no-dsa no-ec no-ecdh no-ecdsa \
+        no-psk no-gost \
+        no-cmac no-scrypt \
+        no-sock no-dgram \
+        no-http no-posix-io no-deprecated no-cached-fetch no-atexit \
+        no-apps no-module no-autoload-config \
+        -Oz -flto \
+        -DOPENSSL_NO_SECURE_MEMORY
+
+    emmake make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)" build_libs
+
+    cd "${ROOT_DIR}"
+    log "OpenSSL built: $(wc -c < "${OPENSSL_SRC}/libcrypto.a") bytes"
+else
+    log "OpenSSL already built — skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Set up secp256k1 private headers (for mpt_scalar.c)
+# ---------------------------------------------------------------------------
+log "Setting up secp256k1 private header symlink"
+mkdir -p "${OBJ_DIR}/private"
+ln -sf "${SECP256K1_SRC}/src"/* "${OBJ_DIR}/private/" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# 4. Compile mpt-crypto sources
+# ---------------------------------------------------------------------------
+log "Compiling mpt-crypto sources"
+
+CFLAGS="-Oz -flto \
+    -I${ROOT_DIR}/include \
+    -I${SECP256K1_SRC}/include \
+    -I${OPENSSL_SRC}/include \
+    -I${OBJ_DIR} \
+    -DSECP256K1_WIDEMUL_INT64"
+
+for f in "${ROOT_DIR}"/src/*.c; do
+    name="$(basename "$f" .c)"
+    if [[ "$f" -nt "${OBJ_DIR}/${name}.o" ]]; then
+        echo "  CC  ${name}.c"
+        emcc ${CFLAGS} -c "$f" -o "${OBJ_DIR}/${name}.o"
+    fi
+done
+
+name="mpt_utility"
+if [[ "${ROOT_DIR}/src/utility/${name}.cpp" -nt "${OBJ_DIR}/${name}.o" ]]; then
+    echo "  CXX ${name}.cpp"
+    em++ ${CFLAGS} -std=c++17 -c "${ROOT_DIR}/src/utility/${name}.cpp" -o "${OBJ_DIR}/${name}.o"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Link final WASM
+# ---------------------------------------------------------------------------
+log "Linking mpt_crypto.wasm"
+
+EXPORTS="_malloc,_free"
+EXPORTS="${EXPORTS},_mpt_secp256k1_context"
+# _mpt_generate_keypair intentionally NOT exported: ElGamal keys come from
+# ripple-keypairs (a separate secp256k1 seed), not the WASM CSPRNG.
+EXPORTS="${EXPORTS},_mpt_generate_blinding_factor"
+EXPORTS="${EXPORTS},_mpt_encrypt_amount,_mpt_decrypt_amount"
+EXPORTS="${EXPORTS},_mpt_get_pedersen_commitment"
+EXPORTS="${EXPORTS},_mpt_get_convert_context_hash,_mpt_get_convert_proof,_mpt_verify_convert_proof"
+EXPORTS="${EXPORTS},_mpt_get_clawback_context_hash,_mpt_get_clawback_proof,_mpt_verify_clawback_proof"
+EXPORTS="${EXPORTS},_mpt_get_convert_back_context_hash,_mpt_get_convert_back_proof,_mpt_verify_convert_back_proof"
+EXPORTS="${EXPORTS},_mpt_get_send_context_hash,_mpt_get_confidential_send_proof,_mpt_verify_send_proof"
+EXPORTS="${EXPORTS},_mpt_verify_revealed_amount"
+EXPORTS="${EXPORTS},_mpt_verify_send_range_proof"
+EXPORTS="${EXPORTS},_mpt_verify_aggregated_bulletproof"
+EXPORTS="${EXPORTS},_mpt_make_ec_pair,_mpt_serialize_ec_pair"
+EXPORTS="${EXPORTS},_mpt_compute_convert_back_remainder"
+
+emcc -Oz -flto \
+    "${OBJ_DIR}"/*.o \
+    "${SECP256K1_BUILD}/lib/libsecp256k1.a" \
+    "${OPENSSL_SRC}/libcrypto.a" \
+    -sMODULARIZE=1 \
+    -sEXPORT_NAME=MptCrypto \
+    -sWASM_BIGINT=1 \
+    -sALLOW_MEMORY_GROWTH=1 \
+    -sEXPORTED_FUNCTIONS="${EXPORTS}" \
+    '-sEXPORTED_RUNTIME_METHODS=["ccall","cwrap","HEAPU8"]' \
+    -sENVIRONMENT=web,node \
+    -o "${OUT_DIR}/mpt_crypto.js"
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+JS_SIZE=$(wc -c < "${OUT_DIR}/mpt_crypto.js")
+WASM_SIZE=$(wc -c < "${OUT_DIR}/mpt_crypto.wasm")
+log "Done!"
+log "  ${OUT_DIR}/mpt_crypto.js   (${JS_SIZE} bytes)"
+log "  ${OUT_DIR}/mpt_crypto.wasm (${WASM_SIZE} bytes)"

--- a/.github/scripts/build-wasm.sh
+++ b/.github/scripts/build-wasm.sh
@@ -90,9 +90,9 @@ log "Dependencies (from conan.lock): secp256k1 ${SECP256K1_VERSION}, openssl ${O
 if [[ ! -f "${SECP256K1_BUILD}/lib/libsecp256k1.a" ]]; then
     log "Building secp256k1 ${SECP256K1_VERSION}"
 
-    if [[ ! -d "${SECP256K1_SRC}/CMakeLists.txt" ]]; then
+    if [[ ! -f "${SECP256K1_SRC}/CMakeLists.txt" ]]; then
         git clone --depth 1 --branch "${SECP256K1_VERSION}" \
-            https://github.com/bitcoin-core/secp256k1.git "${SECP256K1_SRC}" 2>/dev/null || true
+            https://github.com/bitcoin-core/secp256k1.git "${SECP256K1_SRC}"
     fi
 
     mkdir -p "${SECP256K1_BUILD}"
@@ -101,6 +101,7 @@ if [[ ! -f "${SECP256K1_BUILD}/lib/libsecp256k1.a" ]]; then
     emcmake cmake .. \
         -DCMAKE_C_FLAGS="-DSECP256K1_WIDEMUL_INT64" \
         -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=OFF \
         -DSECP256K1_BUILD_TESTS=OFF \
         -DSECP256K1_BUILD_BENCHMARK=OFF \
         -DSECP256K1_BUILD_CTIME_TESTS=OFF \

--- a/.github/scripts/build-wasm.sh
+++ b/.github/scripts/build-wasm.sh
@@ -121,6 +121,20 @@ if [[ ! -f "${SECP256K1_BUILD}/lib/libsecp256k1.a" ]]; then
     mkdir -p "${SECP256K1_BUILD}"
     cd "${SECP256K1_BUILD}"
 
+    # The non-obvious flags below:
+    #  - SECP256K1_WIDEMUL_INT64: wasm32 has no native 128-bit integer, so force
+    #    the 64-bit field backend. This MUST match the mpt-crypto sources (step 4)
+    #    and the test build (test-wasm.sh's HAVE___INT128=FALSE) — the widemul
+    #    choice changes secp256k1's internal struct layout, so any mismatch is a
+    #    silent ABI break at link time.
+    #  - BUILD_SHARED_LIBS=OFF: force a static libsecp256k1.a. Some CI runners
+    #    default this ON, which builds a .so instead and makes the final emcc link
+    #    (step 5) fail with "libsecp256k1.a: No such file or directory".
+    #  - Only the ECDH module is enabled — the one curve op mpt-crypto needs; the
+    #    rest stay off to keep the wasm small.
+    #  - ECMULT_WINDOW_SIZE / ECMULT_GEN_KB size the precomputed tables: a
+    #    speed-vs-binary-size tradeoff only. They do NOT change results, so they
+    #    have no bearing on proof interop with rippled.
     emcmake cmake .. \
         -DCMAKE_C_FLAGS="-DSECP256K1_WIDEMUL_INT64" \
         -DCMAKE_BUILD_TYPE=Release \
@@ -169,7 +183,13 @@ if [[ ! -f "${OPENSSL_SRC}/libcrypto.a" ]]; then
 
     cd "${OPENSSL_SRC}"
 
-    # Heavily stripped configure — only SHA-256, SHA-512, RAND_bytes, OPENSSL_cleanse
+    # Heavily stripped configure — mpt-crypto only needs SHA-256/512, RAND_bytes,
+    # and OPENSSL_cleanse, so everything else is disabled both to shrink the wasm
+    # and to drop code that needs syscalls Emscripten can't provide. Key choices:
+    #  - linux-generic32: a portable, asm-free 32-bit C target (wasm32 is 32-bit).
+    #    CC=emcc does the actual compile, so --cross-compile-prefix stays empty.
+    #  - OPENSSL_NO_SECURE_MEMORY: the secure heap relies on mmap/madvise, which
+    #    aren't available under wasm.
     perl Configure linux-generic32 \
         --cross-compile-prefix= \
         CC=emcc AR=emar RANLIB=emranlib \
@@ -189,6 +209,8 @@ if [[ ! -f "${OPENSSL_SRC}/libcrypto.a" ]]; then
         -Oz -flto \
         -DOPENSSL_NO_SECURE_MEMORY
 
+    # build_libs (not the default target) builds only libcrypto/libssl — we never
+    # need the openssl apps or test binaries.
     emmake make -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)" build_libs
 
     cd "${ROOT_DIR}"
@@ -200,6 +222,10 @@ fi
 # ---------------------------------------------------------------------------
 # 3. Set up secp256k1 private headers (for mpt_scalar.c)
 # ---------------------------------------------------------------------------
+# mpt_scalar.c reuses secp256k1's internal field/scalar arithmetic, which lives
+# in secp256k1's src/ (not its public include/) and is pulled in as <private/...>.
+# Symlink that src/ tree under obj/private/ so -I${OBJ_DIR} resolves those
+# includes. test-wasm.sh reuses the same symlinks (it puts ${OBJ_DIR} on -I too).
 log "Setting up secp256k1 private header symlink"
 mkdir -p "${OBJ_DIR}/private"
 ln -sf "${SECP256K1_SRC}/src"/* "${OBJ_DIR}/private/" 2>/dev/null || true
@@ -242,16 +268,33 @@ EXPORTS="${EXPORTS},_mpt_secp256k1_context"
 EXPORTS="${EXPORTS},_mpt_generate_blinding_factor"
 EXPORTS="${EXPORTS},_mpt_encrypt_amount,_mpt_decrypt_amount"
 EXPORTS="${EXPORTS},_mpt_get_pedersen_commitment"
+# Per-transaction context-hash + proof entries. On each line the get_*_context_hash
+# and get_*_proof (generator) symbols ARE called by the @xrplf/mpt-crypto TS
+# wrapper; the paired _mpt_verify_* symbols are NOT — the wrapper only generates
+# proofs, never verifies. The verifiers (here and the standalone group below) are
+# kept for consumers that verify client-side / for parity with the native lib;
+# they're safe to drop if you want a smaller module. Keep this list in sync with
+# @xrplf/mpt-crypto's index.ts (unexported symbols get dead-stripped downstream).
 EXPORTS="${EXPORTS},_mpt_get_convert_context_hash,_mpt_get_convert_proof,_mpt_verify_convert_proof"
 EXPORTS="${EXPORTS},_mpt_get_clawback_context_hash,_mpt_get_clawback_proof,_mpt_verify_clawback_proof"
 EXPORTS="${EXPORTS},_mpt_get_convert_back_context_hash,_mpt_get_convert_back_proof,_mpt_verify_convert_back_proof"
 EXPORTS="${EXPORTS},_mpt_get_send_context_hash,_mpt_get_confidential_send_proof,_mpt_verify_send_proof"
+# Standalone verifiers + low-level helpers — none used by the TS wrapper today
+# (see the note above); exported for client-side verification / native parity.
 EXPORTS="${EXPORTS},_mpt_verify_revealed_amount"
 EXPORTS="${EXPORTS},_mpt_verify_send_range_proof"
 EXPORTS="${EXPORTS},_mpt_verify_aggregated_bulletproof"
 EXPORTS="${EXPORTS},_mpt_make_ec_pair,_mpt_serialize_ec_pair"
 EXPORTS="${EXPORTS},_mpt_compute_convert_back_remainder"
 
+# Why these -s link flags (they define the JS-facing contract, so don't drop them
+# without checking the @xrplf/mpt-crypto TS wrapper):
+#  - MODULARIZE + EXPORT_NAME: emit a factory `MptCrypto()` instead of a global,
+#    so the module can be require()'d / imported and loaded lazily.
+#  - WASM_BIGINT: marshal i64 <-> JS BigInt directly — mpt amounts are uint64_t.
+#  - ALLOW_MEMORY_GROWTH: bulletproof generation allocates a lot; let the heap grow.
+#  - EXPORTED_RUNTIME_METHODS: the TS marshalling layer needs HEAPU8 + ccall/cwrap.
+#  - ENVIRONMENT=web,node: xrpl.js runs in both browsers and Node, so build for both.
 emcc -Oz -flto \
     "${OBJ_DIR}"/*.o \
     "${SECP256K1_BUILD}/lib/libsecp256k1.a" \

--- a/.github/scripts/build-wasm.sh
+++ b/.github/scripts/build-wasm.sh
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 # build-wasm.sh — Build the shipped mpt-crypto WebAssembly module.
 #
-# Produces the single JS-consumable artifact that downstream JS/TS libraries
+# Produces the JS-consumable artifacts that downstream JS/TS libraries
 # (e.g. xrpl.js) vendor:
-#   emcc_out/mpt_crypto.js    (Emscripten MODULARIZE glue / loader)
+#   emcc_out/mpt_crypto.js    (Emscripten MODULARIZE CommonJS glue / loader)
+#   emcc_out/mpt_crypto.mjs   (EXPORT_ES6 ES-module glue for bundlers/browsers)
 #   emcc_out/mpt_crypto.wasm  (the compiled module, curated exports)
 #
 # Builds ONLY the module (not tests) — the companion test-wasm.sh validates it
 # by running the crypto suite under Node; the CI workflow runs both in order.
-# It has a dedicated emcc link (rather than CMake, like the native shared lib)
-# because the wasm module needs MODULARIZE/exports/WASM_BIGINT.
+# It has a dedicated emcc link (rather than CMake) because the wasm module needs
+# MODULARIZE/exports/WASM_BIGINT.
 #
 # As a side effect it builds the wasm-target secp256k1 + OpenSSL static libs
 # into emcc_build/, which test-wasm.sh reuses.
@@ -114,7 +115,8 @@ if [[ ! -f "${SECP256K1_BUILD}/lib/libsecp256k1.a" ]]; then
     # not. Verify the checked-out commit against the pin.
     actual_sha="$(git -C "${SECP256K1_SRC}" rev-parse HEAD)"
     if [[ "${actual_sha}" != "${SECP256K1_COMMIT}" ]]; then
-        echo "ERROR: secp256k1 ${SECP256K1_VERSION} is ${actual_sha}, expected ${SECP256K1_COMMIT}" >&2
+        echo "ERROR: secp256k1 ${SECP256K1_VERSION} is ${actual_sha}, expected ${SECP256K1_COMMIT}." >&2
+        echo "       If conan.lock bumped secp256k1, update SECP256K1_COMMIT in this script." >&2
         exit 1
     fi
 
@@ -169,11 +171,14 @@ if [[ ! -f "${OPENSSL_SRC}/libcrypto.a" ]]; then
     if [[ ! -d "${OPENSSL_SRC}" ]]; then
         cd "${BUILD_DIR}"
         openssl_tarball="openssl-${OPENSSL_VERSION}.tar.gz"
-        curl -sL "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/${openssl_tarball}" \
+        # --fail so an HTTP error (e.g. 404) aborts here with a clear status,
+        # rather than saving the error body and surfacing as a hash mismatch.
+        curl -fsSL "https://github.com/openssl/openssl/releases/download/openssl-${OPENSSL_VERSION}/${openssl_tarball}" \
             -o "${openssl_tarball}"
         got="$(sha256_of "${openssl_tarball}")"
         if [[ "${got}" != "${OPENSSL_SHA256}" ]]; then
-            echo "ERROR: ${openssl_tarball} sha256 ${got}, expected ${OPENSSL_SHA256}" >&2
+            echo "ERROR: ${openssl_tarball} sha256 ${got}, expected ${OPENSSL_SHA256}." >&2
+            echo "       If conan.lock bumped openssl, update OPENSSL_SHA256 in this script." >&2
             exit 1
         fi
         tar xzf "${openssl_tarball}"
@@ -242,18 +247,28 @@ CFLAGS="-Oz -flto \
     -I${OBJ_DIR} \
     -DSECP256K1_WIDEMUL_INT64"
 
+# Collect the objects for THIS source set explicitly and link that list (not a
+# ${OBJ_DIR}/*.o glob), so a renamed or deleted source can't leave a stale .o
+# behind for the link to silently pick up. Caveat: the -nt check compares only
+# the source's mtime, not its headers — after editing a header, rebuild with
+# --clean (or delete emcc_build/obj) to force recompilation.
+OBJECTS=()
 for f in "${ROOT_DIR}"/src/*.c; do
     name="$(basename "$f" .c)"
-    if [[ "$f" -nt "${OBJ_DIR}/${name}.o" ]]; then
+    obj="${OBJ_DIR}/${name}.o"
+    OBJECTS+=("${obj}")
+    if [[ "$f" -nt "${obj}" ]]; then
         echo "  CC  ${name}.c"
-        emcc ${CFLAGS} -c "$f" -o "${OBJ_DIR}/${name}.o"
+        emcc ${CFLAGS} -c "$f" -o "${obj}"
     fi
 done
 
 name="mpt_utility"
-if [[ "${ROOT_DIR}/src/utility/${name}.cpp" -nt "${OBJ_DIR}/${name}.o" ]]; then
+obj="${OBJ_DIR}/${name}.o"
+OBJECTS+=("${obj}")
+if [[ "${ROOT_DIR}/src/utility/${name}.cpp" -nt "${obj}" ]]; then
     echo "  CXX ${name}.cpp"
-    em++ ${CFLAGS} -std=c++17 -c "${ROOT_DIR}/src/utility/${name}.cpp" -o "${OBJ_DIR}/${name}.o"
+    em++ ${CFLAGS} -std=c++17 -c "${ROOT_DIR}/src/utility/${name}.cpp" -o "${obj}"
 fi
 
 # ---------------------------------------------------------------------------
@@ -272,15 +287,15 @@ EXPORTS="${EXPORTS},_mpt_get_pedersen_commitment"
 # and get_*_proof (generator) symbols ARE called by the @xrplf/mpt-crypto TS
 # wrapper; the paired _mpt_verify_* symbols are NOT — the wrapper only generates
 # proofs, never verifies. The verifiers (here and the standalone group below) are
-# kept for consumers that verify client-side / for parity with the native lib;
-# they're safe to drop if you want a smaller module. Keep this list in sync with
+# kept for consumers that verify client-side; they're safe to drop if you want a
+# smaller module. Keep this list in sync with
 # @xrplf/mpt-crypto's index.ts (unexported symbols get dead-stripped downstream).
 EXPORTS="${EXPORTS},_mpt_get_convert_context_hash,_mpt_get_convert_proof,_mpt_verify_convert_proof"
 EXPORTS="${EXPORTS},_mpt_get_clawback_context_hash,_mpt_get_clawback_proof,_mpt_verify_clawback_proof"
 EXPORTS="${EXPORTS},_mpt_get_convert_back_context_hash,_mpt_get_convert_back_proof,_mpt_verify_convert_back_proof"
 EXPORTS="${EXPORTS},_mpt_get_send_context_hash,_mpt_get_confidential_send_proof,_mpt_verify_send_proof"
 # Standalone verifiers + low-level helpers — none used by the TS wrapper today
-# (see the note above); exported for client-side verification / native parity.
+# (see the note above); exported for client-side verification.
 EXPORTS="${EXPORTS},_mpt_verify_revealed_amount"
 EXPORTS="${EXPORTS},_mpt_verify_send_range_proof"
 EXPORTS="${EXPORTS},_mpt_verify_aggregated_bulletproof"
@@ -297,7 +312,7 @@ EXPORTS="${EXPORTS},_mpt_compute_convert_back_remainder"
 #  - ENVIRONMENT=web,node: xrpl.js runs in both browsers and Node, so build for both.
 LINK_FLAGS=(
     -Oz -flto
-    "${OBJ_DIR}"/*.o
+    "${OBJECTS[@]}"
     "${SECP256K1_BUILD}/lib/libsecp256k1.a"
     "${OPENSSL_SRC}/libcrypto.a"
     -sMODULARIZE=1
@@ -318,7 +333,18 @@ LINK_FLAGS=(
 #                      auto-emit the .wasm as an asset instead of a runtime read).
 # Keep these two links in lockstep; the .mjs is what makes the browser path work.
 emcc "${LINK_FLAGS[@]}" -o "${OUT_DIR}/mpt_crypto.js"
+wasm_sha_cjs="$(sha256_of "${OUT_DIR}/mpt_crypto.wasm")"
 emcc "${LINK_FLAGS[@]}" -sEXPORT_ES6=1 -o "${OUT_DIR}/mpt_crypto.mjs"
+wasm_sha_esm="$(sha256_of "${OUT_DIR}/mpt_crypto.wasm")"
+
+# The second link (EXPORT_ES6) overwrites the .wasm the first emitted. Both are
+# meant to wrap the byte-identical module, so enforce it — if they ever diverge,
+# the CJS glue would ship validated against a .wasm that no longer exists on disk.
+if [[ "${wasm_sha_cjs}" != "${wasm_sha_esm}" ]]; then
+    echo "ERROR: CJS and ESM links produced different mpt_crypto.wasm" >&2
+    echo "       (${wasm_sha_cjs} vs ${wasm_sha_esm})" >&2
+    exit 1
+fi
 
 # ---------------------------------------------------------------------------
 # Done

--- a/.github/scripts/build-wasm.sh
+++ b/.github/scripts/build-wasm.sh
@@ -295,24 +295,38 @@ EXPORTS="${EXPORTS},_mpt_compute_convert_back_remainder"
 #  - ALLOW_MEMORY_GROWTH: bulletproof generation allocates a lot; let the heap grow.
 #  - EXPORTED_RUNTIME_METHODS: the TS marshalling layer needs HEAPU8 + ccall/cwrap.
 #  - ENVIRONMENT=web,node: xrpl.js runs in both browsers and Node, so build for both.
-emcc -Oz -flto \
-    "${OBJ_DIR}"/*.o \
-    "${SECP256K1_BUILD}/lib/libsecp256k1.a" \
-    "${OPENSSL_SRC}/libcrypto.a" \
-    -sMODULARIZE=1 \
-    -sEXPORT_NAME=MptCrypto \
-    -sWASM_BIGINT=1 \
-    -sALLOW_MEMORY_GROWTH=1 \
-    -sEXPORTED_FUNCTIONS="${EXPORTS}" \
-    '-sEXPORTED_RUNTIME_METHODS=["ccall","cwrap","HEAPU8"]' \
-    -sENVIRONMENT=web,node \
-    -o "${OUT_DIR}/mpt_crypto.js"
+LINK_FLAGS=(
+    -Oz -flto
+    "${OBJ_DIR}"/*.o
+    "${SECP256K1_BUILD}/lib/libsecp256k1.a"
+    "${OPENSSL_SRC}/libcrypto.a"
+    -sMODULARIZE=1
+    -sEXPORT_NAME=MptCrypto
+    -sWASM_BIGINT=1
+    -sALLOW_MEMORY_GROWTH=1
+    -sEXPORTED_FUNCTIONS="${EXPORTS}"
+    '-sEXPORTED_RUNTIME_METHODS=["ccall","cwrap","HEAPU8"]'
+    -sENVIRONMENT=web,node
+)
+
+# @xrplf/mpt-crypto ships dual CJS+ESM so the same package works under Node
+# `require`/Jest AND under bundlers/browsers via `import`. Emit BOTH Emscripten
+# glues from the identical objects — they wrap the SAME mpt_crypto.wasm:
+#   - mpt_crypto.js  : MODULARIZE CommonJS  (require()'d by the CJS build)
+#   - mpt_crypto.mjs : EXPORT_ES6 ES module (imported by the ESM build; uses
+#                      `new URL('mpt_crypto.wasm', import.meta.url)` so bundlers
+#                      auto-emit the .wasm as an asset instead of a runtime read).
+# Keep these two links in lockstep; the .mjs is what makes the browser path work.
+emcc "${LINK_FLAGS[@]}" -o "${OUT_DIR}/mpt_crypto.js"
+emcc "${LINK_FLAGS[@]}" -sEXPORT_ES6=1 -o "${OUT_DIR}/mpt_crypto.mjs"
 
 # ---------------------------------------------------------------------------
 # Done
 # ---------------------------------------------------------------------------
 JS_SIZE=$(wc -c < "${OUT_DIR}/mpt_crypto.js")
+MJS_SIZE=$(wc -c < "${OUT_DIR}/mpt_crypto.mjs")
 WASM_SIZE=$(wc -c < "${OUT_DIR}/mpt_crypto.wasm")
 log "Done!"
 log "  ${OUT_DIR}/mpt_crypto.js   (${JS_SIZE} bytes)"
+log "  ${OUT_DIR}/mpt_crypto.mjs  (${MJS_SIZE} bytes)"
 log "  ${OUT_DIR}/mpt_crypto.wasm (${WASM_SIZE} bytes)"

--- a/.github/scripts/build-wasm.sh
+++ b/.github/scripts/build-wasm.sh
@@ -307,7 +307,17 @@ EXPORTS="${EXPORTS},_mpt_compute_convert_back_remainder"
 #  - MODULARIZE + EXPORT_NAME: emit a factory `MptCrypto()` instead of a global,
 #    so the module can be require()'d / imported and loaded lazily.
 #  - WASM_BIGINT: marshal i64 <-> JS BigInt directly — mpt amounts are uint64_t.
-#  - ALLOW_MEMORY_GROWTH: bulletproof generation allocates a lot; let the heap grow.
+#  - ALLOW_MEMORY_GROWTH: let the heap grow on demand instead of reserving a fixed
+#    block up front.
+#  - GROWABLE_ARRAYBUFFERS=0: emsdk 6.x defaults this to 1, which grows the heap in
+#    place backed by a RESIZABLE ArrayBuffer. A subarray of a resizable buffer makes
+#    TextDecoder.decode throw in Chrome ("ArrayBuffer must not be resizable"), which
+#    breaks the xrpl.js browser tests. Setting 0 keeps growth but reallocates a plain
+#    (non-resizable) buffer on each grow — browser-safe, and no fixed memory cap.
+#  - MAXIMUM_MEMORY=128MB: a defense-in-depth ceiling. The real working set is small
+#    and stable — dominated by secp256k1's static tables, with per-op allocations
+#    freed and reused, so it does not grow over time — and stays far below this cap.
+#    The ceiling just bounds a hypothetical runaway well under the 2GB default.
 #  - EXPORTED_RUNTIME_METHODS: the TS marshalling layer needs HEAPU8 + ccall/cwrap.
 #  - ENVIRONMENT=web,node: xrpl.js runs in both browsers and Node, so build for both.
 LINK_FLAGS=(
@@ -319,6 +329,8 @@ LINK_FLAGS=(
     -sEXPORT_NAME=MptCrypto
     -sWASM_BIGINT=1
     -sALLOW_MEMORY_GROWTH=1
+    -sGROWABLE_ARRAYBUFFERS=0
+    -sMAXIMUM_MEMORY=134217728
     -sEXPORTED_FUNCTIONS="${EXPORTS}"
     '-sEXPORTED_RUNTIME_METHODS=["ccall","cwrap","HEAPU8"]'
     -sENVIRONMENT=web,node

--- a/.github/scripts/test-wasm.sh
+++ b/.github/scripts/test-wasm.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# test-wasm.sh — Validate the mpt-crypto WASM build.
+#
+# Compiles the C/C++ crypto test suite to wasm32 (emcmake + CMake) and runs each
+# test under Node via ctest, so the crypto is exercised on the wasm target.
+#
+# Requires .github/scripts/build-wasm.sh to have run first: it REUSES the
+# wasm-target secp256k1 + OpenSSL builds and the private-header symlinks that
+# build-wasm.sh produced under emcc_build/ (same versions, same forced
+# SECP256K1_WIDEMUL_INT64), so the tests link the exact field arithmetic that
+# ships. This is the WASM analog of the `ctest` step in build-shared-lib.sh.
+#
+# Prerequisites: Emscripten SDK (emcc/em++/emcmake), Node, and cmake on PATH.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+BUILD_DIR="${ROOT_DIR}/emcc_build"
+SECP256K1_LIB="${BUILD_DIR}/secp256k1/build/lib/libsecp256k1.a"
+if [[ ! -f "${SECP256K1_LIB}" ]]; then
+  echo "ERROR: wasm dependencies not found under ${BUILD_DIR}." >&2
+  echo "       Run ./.github/scripts/build-wasm.sh first." >&2
+  exit 1
+fi
+
+SECP256K1_INC="${BUILD_DIR}/secp256k1/include"
+# build-wasm.sh symlinks secp256k1's private src/ headers under obj/private/;
+# mpt_scalar.c includes them as <private/...>, so this dir must be on -I.
+PRIVATE_INC="${BUILD_DIR}/obj"
+OPENSSL_DIR="$(dirname "$(find "${BUILD_DIR}" -maxdepth 2 -name libcrypto.a | head -n1)")"
+
+TEST_BUILD="${BUILD_DIR}/wasm-tests"
+DEPS_DIR="${BUILD_DIR}/wasm-deps"
+rm -rf "${TEST_BUILD}"
+mkdir -p "${DEPS_DIR}"
+
+# build-wasm.sh builds secp256k1 but does not `install` it, so there is no
+# find_package config. Provide a minimal one pointing at the prebuilt archive.
+cat > "${DEPS_DIR}/secp256k1-config.cmake" <<EOF
+if(NOT TARGET secp256k1::secp256k1)
+  add_library(secp256k1::secp256k1 STATIC IMPORTED)
+  set_target_properties(secp256k1::secp256k1 PROPERTIES
+    IMPORTED_LOCATION "${SECP256K1_LIB}"
+    INTERFACE_INCLUDE_DIRECTORIES "${SECP256K1_INC}")
+endif()
+set(secp256k1_FOUND TRUE)
+EOF
+
+# HAVE___INT128=FALSE forces SECP256K1_WIDEMUL_INT64 to match the prebuilt
+# secp256k1 (a mismatch changes secp256k1's internal struct layout -> ABI break).
+# CMAKE_FIND_ROOT_PATH_MODE_*=BOTH lets find_package see the host-path deps
+# under the Emscripten (cross-compile) toolchain.
+emcmake cmake -S "${ROOT_DIR}" -B "${TEST_BUILD}" \
+  -G "Unix Makefiles" \
+  -DENABLE_TESTS=ON \
+  -DMPT_CRYPTO_WERROR=OFF \
+  -DHAVE___INT128=FALSE \
+  -Dsecp256k1_DIR="${DEPS_DIR}" \
+  -DOPENSSL_USE_STATIC_LIBS=ON \
+  -DOPENSSL_CRYPTO_LIBRARY="${OPENSSL_DIR}/libcrypto.a" \
+  -DOPENSSL_INCLUDE_DIR="${OPENSSL_DIR}/include" \
+  -DCMAKE_C_FLAGS="-I${PRIVATE_INC}" \
+  -DCMAKE_CXX_FLAGS="-I${PRIVATE_INC}" \
+  -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
+  -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=BOTH \
+  -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=BOTH \
+  -DCMAKE_CROSSCOMPILING_EMULATOR="$(command -v node)"
+
+cmake --build "${TEST_BUILD}" -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
+
+# Each test executable is a wasm module; ctest runs it as `node test_*.js`.
+cd "${TEST_BUILD}"
+ctest --output-on-failure

--- a/.github/scripts/test-wasm.sh
+++ b/.github/scripts/test-wasm.sh
@@ -81,3 +81,31 @@ cmake --build "${TEST_BUILD}" -j"$(nproc 2>/dev/null || sysctl -n hw.ncpu)"
 # Each test executable is a wasm module; ctest runs it as `node test_*.js`.
 cd "${TEST_BUILD}"
 ctest --output-on-failure
+
+# ---------------------------------------------------------------------------
+# Smoke-test the shipped glue
+# ---------------------------------------------------------------------------
+# ctest above validates the crypto on its own test binaries; it never loads the
+# MODULARIZE (.js) / EXPORT_ES6 (.mjs) glue build-wasm.sh actually ships. Load each
+# the way consumers do (require / import) and exercise the marshalling contract the
+# wrapper needs: instantiate, init the secp256k1 context, and run one malloc+HEAPU8
+# export. A bad -s flag fails here instead of downstream. (Crypto correctness is
+# ctest's job — this only guards the glue/ABI.)
+GLUE_DIR="${ROOT_DIR}/emcc_out"
+echo "Smoke-testing the CJS + ESM glue..."
+node --input-type=module -e "
+import { createRequire } from 'module'
+const require = createRequire(import.meta.url)
+async function check(label, factory) {
+  const m = await factory()
+  if (m._mpt_secp256k1_context() === 0) throw new Error(label + ': context init failed')
+  const ptr = m._malloc(32)
+  const rc = m._mpt_generate_blinding_factor(ptr)
+  const written = m.HEAPU8.slice(ptr, ptr + 32).some(b => b !== 0)
+  m._free(ptr)
+  if (rc !== 0 || !written) throw new Error(label + ': marshalling path failed')
+  console.log('  ' + label + ' OK')
+}
+await check('mpt_crypto.js  (CJS)', require('${GLUE_DIR}/mpt_crypto.js'))
+await check('mpt_crypto.mjs (ESM)', (await import('${GLUE_DIR}/mpt_crypto.mjs')).default)
+"

--- a/.github/scripts/test-wasm.sh
+++ b/.github/scripts/test-wasm.sh
@@ -28,7 +28,16 @@ SECP256K1_INC="${BUILD_DIR}/secp256k1/include"
 # build-wasm.sh symlinks secp256k1's private src/ headers under obj/private/;
 # mpt_scalar.c includes them as <private/...>, so this dir must be on -I.
 PRIVATE_INC="${BUILD_DIR}/obj"
-OPENSSL_DIR="$(dirname "$(find "${BUILD_DIR}" -maxdepth 2 -name libcrypto.a | head -n1)")"
+# Guard the find like the secp256k1 check above: an empty result would make
+# dirname yield "." and fail far later as a confusing cmake error; a leftover
+# openssl-<old>/ after a version bump would also make the pick arbitrary.
+OPENSSL_LIB="$(find "${BUILD_DIR}" -maxdepth 2 -name libcrypto.a | head -n1)"
+if [[ -z "${OPENSSL_LIB}" ]]; then
+  echo "ERROR: OpenSSL libcrypto.a not found under ${BUILD_DIR}." >&2
+  echo "       Run ./.github/scripts/build-wasm.sh first." >&2
+  exit 1
+fi
+OPENSSL_DIR="$(dirname "${OPENSSL_LIB}")"
 
 TEST_BUILD="${BUILD_DIR}/wasm-tests"
 DEPS_DIR="${BUILD_DIR}/wasm-deps"
@@ -91,7 +100,11 @@ ctest --output-on-failure
 # wrapper needs: instantiate, init the secp256k1 context, and run one malloc+HEAPU8
 # export. A bad -s flag fails here instead of downstream. (Crypto correctness is
 # ctest's job — this only guards the glue/ABI.)
-GLUE_DIR="${ROOT_DIR}/emcc_out"
+#
+# GLUE_DIR defaults to emcc_out (the freshly built tree) for local runs. CI
+# overrides it to the STAGED bundle dir so this validates exactly what ships —
+# a file dropped from the bundle fails here instead of shipping green.
+GLUE_DIR="${GLUE_DIR:-${ROOT_DIR}/emcc_out}"
 echo "Smoke-testing the CJS + ESM glue..."
 node --input-type=module -e "
 import { createRequire } from 'module'

--- a/.github/scripts/test-wasm.sh
+++ b/.github/scripts/test-wasm.sh
@@ -47,10 +47,19 @@ endif()
 set(secp256k1_FOUND TRUE)
 EOF
 
-# HAVE___INT128=FALSE forces SECP256K1_WIDEMUL_INT64 to match the prebuilt
-# secp256k1 (a mismatch changes secp256k1's internal struct layout -> ABI break).
-# CMAKE_FIND_ROOT_PATH_MODE_*=BOTH lets find_package see the host-path deps
-# under the Emscripten (cross-compile) toolchain.
+# Non-obvious flags below:
+#  - HAVE___INT128=FALSE forces SECP256K1_WIDEMUL_INT64 to match the prebuilt
+#    secp256k1 from build-wasm.sh (a mismatch changes secp256k1's internal struct
+#    layout -> ABI break). This mirrors build-wasm.sh's -DSECP256K1_WIDEMUL_INT64.
+#  - CMAKE_FIND_ROOT_PATH_MODE_*=BOTH lets find_package see the host-path deps
+#    (our prebuilt archives) under the Emscripten cross-compile toolchain, which
+#    otherwise only searches the emscripten sysroot.
+#  - CMAKE_CROSSCOMPILING_EMULATOR=node makes ctest run each wasm test as
+#    `node test_*.js` (the test binaries are wasm, not native executables).
+#  - -G "Unix Makefiles" pins the generator so CI doesn't pick up Ninja/Xcode.
+#  - MPT_CRYPTO_WERROR=OFF: wasm/toolchain warnings shouldn't fail the test build.
+#  - OPENSSL_USE_STATIC_LIBS + explicit CRYPTO_LIBRARY/INCLUDE_DIR point at the
+#    stripped libcrypto.a from build-wasm.sh, never a system OpenSSL.
 emcmake cmake -S "${ROOT_DIR}" -B "${TEST_BUILD}" \
   -G "Unix Makefiles" \
   -DENABLE_TESTS=ON \

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -1,0 +1,65 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Build WASM Module
+#
+# Builds the mpt-crypto C library as a single portable WebAssembly module
+# (mpt_crypto.js glue + mpt_crypto.wasm) for JS/TS consumers (xrpl.js). Unlike
+# the native shared libraries there is NO OS x arch matrix: one wasm32 artifact
+# runs in every browser and in Node/Deno/Bun on any platform/endianness.
+#
+# The build also validates the artifact: .github/scripts/build-wasm.sh compiles
+# the C crypto test suite to wasm and runs it under Node (ctest), so the module
+# is exercised before it is bundled — the WASM analog of what build-shared-lib.sh
+# does with ctest for the native libraries.
+#
+# Invoked via `workflow_call` from build.yml — on every PR and push to main (so
+# the build+test path is exercised), and on tag push (so build.yml can attach the
+# bundle to the release, which JS consumers download).
+#
+# The `build` job uploads `mpt-crypto-wasm-bundle` (mpt_crypto.js + .wasm), which
+# the caller downloads and attaches to the GitHub release.
+# ──────────────────────────────────────────────────────────────────────────────
+
+name: Build WASM Module
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Build + test WASM module
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Emscripten
+        uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
+        with:
+          # Pinned for reproducible wasm output. The emsdk version does not
+          # affect crypto results, only the binary's codegen/size.
+          version: 6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: "22"
+
+      - name: Build WASM module
+        run: ./.github/scripts/build-wasm.sh
+
+      - name: Test WASM module
+        run: ./.github/scripts/test-wasm.sh
+
+      - name: Stage WASM bundle
+        run: |
+          mkdir -p output
+          cp emcc_out/mpt_crypto.js emcc_out/mpt_crypto.wasm output/
+          tar -czf mpt-crypto-wasm.tar.gz -C output .
+
+      - name: Upload bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mpt-crypto-wasm-bundle
+          path: mpt-crypto-wasm.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Set up Emscripten
         uses: mymindstorm/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
         with:
-          # Pinned for reproducible wasm output. The emsdk version does not
-          # affect crypto results, only the binary's codegen/size.
+          # Pinned for reproducible wasm output. The emsdk version does not change
+          # crypto results (browser-safety is handled by GROWABLE_ARRAYBUFFERS=0 in
+          # build-wasm.sh — see the note there on resizable ArrayBuffers).
           version: 6.0.2
 
       - name: Set up Node

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -2,21 +2,22 @@
 # Build WASM Module
 #
 # Builds the mpt-crypto C library as a single portable WebAssembly module
-# (mpt_crypto.js glue + mpt_crypto.wasm) for JS/TS consumers (xrpl.js). Unlike
-# the native shared libraries there is NO OS x arch matrix: one wasm32 artifact
-# runs in every browser and in Node/Deno/Bun on any platform/endianness.
+# (mpt_crypto.js CommonJS glue + mpt_crypto.mjs ES-module glue + mpt_crypto.wasm)
+# for JS/TS consumers (xrpl.js). There is NO OS x arch matrix: one wasm32
+# artifact runs in every browser and in Node/Deno/Bun on any
+# platform/endianness.
 #
-# The build also validates the artifact: .github/scripts/build-wasm.sh compiles
-# the C crypto test suite to wasm and runs it under Node (ctest), so the module
-# is exercised before it is bundled — the WASM analog of what build-shared-lib.sh
-# does with ctest for the native libraries.
+# The artifact is validated before upload: .github/scripts/test-wasm.sh compiles
+# the C crypto test suite to wasm and runs it under Node (ctest), then smoke-tests
+# the shipped glue. The smoke test runs against the STAGED bundle, so a file
+# dropped from the bundle fails CI instead of shipping green.
 #
 # Invoked via `workflow_call` from build.yml — on every PR and push to main (so
 # the build+test path is exercised), and on tag push (so build.yml can attach the
 # bundle to the release, which JS consumers download).
 #
-# The `build` job uploads `mpt-crypto-wasm-bundle` (mpt_crypto.js + .wasm), which
-# the caller downloads and attaches to the GitHub release.
+# The `build` job uploads `mpt-crypto-wasm-bundle` (mpt_crypto.js + .mjs + .wasm),
+# which the caller downloads and attaches to the GitHub release.
 # ──────────────────────────────────────────────────────────────────────────────
 
 name: Build WASM Module
@@ -48,14 +49,21 @@ jobs:
       - name: Build WASM module
         run: ./.github/scripts/build-wasm.sh
 
-      - name: Test WASM module
-        run: ./.github/scripts/test-wasm.sh
-
       - name: Stage WASM bundle
+        # Stage BEFORE testing so the smoke test validates exactly what ships.
         run: |
           mkdir -p output
-          cp emcc_out/mpt_crypto.js emcc_out/mpt_crypto.wasm output/
-          tar -czf mpt-crypto-wasm.tar.gz -C output .
+          cp emcc_out/mpt_crypto.js emcc_out/mpt_crypto.mjs emcc_out/mpt_crypto.wasm output/
+
+      - name: Test WASM module
+        # Point the glue smoke test at the staged bundle, not emcc_out, so a file
+        # dropped from output/ fails here instead of shipping.
+        env:
+          GLUE_DIR: ${{ github.workspace }}/output
+        run: ./.github/scripts/test-wasm.sh
+
+      - name: Package WASM bundle
+        run: tar -czf mpt-crypto-wasm.tar.gz -C output .
 
       - name: Upload bundle
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,11 +106,19 @@ jobs:
       contents: read
     uses: ./.github/workflows/build-shared-libs.yml
 
-  # On tag push only: publish a GitHub release and attach the native bundle.
+  # Build the portable WebAssembly module (mpt_crypto.js + .wasm) for JS/TS
+  # consumers (e.g. xrpl.js) by calling the reusable workflow.
+  wasm:
+    name: Build WASM module
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-wasm.yml
+
+  # On tag push only: publish a GitHub release and attach the native + wasm bundles.
   release:
     name: Publish release
     if: github.ref_type == 'tag'
-    needs: [build-and-test, native-binaries]
+    needs: [build-and-test, native-binaries, wasm]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -120,19 +128,27 @@ jobs:
         with:
           name: mpt-crypto-natives-bundle
 
+      - name: Download WASM bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: mpt-crypto-wasm-bundle
+
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ARCHIVE="mpt-crypto-natives-${GITHUB_REF_NAME}.tar.gz"
-          mv mpt-crypto-natives.tar.gz "${ARCHIVE}"
+          NATIVES="mpt-crypto-natives-${GITHUB_REF_NAME}.tar.gz"
+          WASM="mpt-crypto-wasm-${GITHUB_REF_NAME}.tar.gz"
+          mv mpt-crypto-natives.tar.gz "${NATIVES}"
+          mv mpt-crypto-wasm.tar.gz "${WASM}"
 
           if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
             PRERELEASE_FLAG="--prerelease"
           fi
 
           gh release create "${GITHUB_REF_NAME}" \
-            "${ARCHIVE}" \
+            "${NATIVES}" \
+            "${WASM}" \
             --repo "${GITHUB_REPOSITORY}" \
             --generate-notes \
             $PRERELEASE_FLAG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,8 +106,8 @@ jobs:
       contents: read
     uses: ./.github/workflows/build-shared-libs.yml
 
-  # Build the portable WebAssembly module (mpt_crypto.js + .wasm) for JS/TS
-  # consumers (e.g. xrpl.js) by calling the reusable workflow.
+  # Build the portable WebAssembly module (mpt_crypto.js + .mjs + .wasm) for
+  # JS/TS consumers (e.g. xrpl.js) by calling the reusable workflow.
   wasm:
     name: Build WASM module
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ cmake-build-*/
 .idea/
 .venv
 .vscode/
+
+# Emscripten build artifacts
+emcc_build/
+emcc_out/
+
+# Compiled WebAssembly
+*.wasm

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ cmake-build-*/
 .venv
 .vscode/
 
-# Emscripten build artifacts
+# Emscripten build artifacts (cover the built .js/.mjs/.wasm outputs)
 emcc_build/
 emcc_out/
-
-# Compiled WebAssembly
-*.wasm


### PR DESCRIPTION
### Why
`mpt-crypto` is used by XRPL client SDKs/libraries in two ways: native shared libraries (xrpl4j, xrpl-py) and a WebAssembly module (xrpl.js). PR #56 gave the **native** libraries a full CI story — build per platform, run `ctest`, bundle, and attach to the GitHub release. The **WASM** module had no equivalent: no CI build, no tests, and no released artifact.

This PR brings WASM to parity, so JS/TS consumers can pull a reproducibly-built, tested wasm module from tagged releases — the same guarantee xrpl4j/xrpl-py already get for the native libs.

## What it adds
```
build-wasm.yml  (one ubuntu job, called by build.yml)
   │
   ├─ setup emsdk 6.0.2 + Node 22
   ├─ build-wasm.sh   → compiles secp256k1 + OpenSSL + mpt-crypto, then links the
   │                    glue TWICE → emcc_out/mpt_crypto.{js, mjs, wasm}
   │                      • mpt_crypto.js   MODULARIZE CommonJS glue
   │                      • mpt_crypto.mjs  EXPORT_ES6 ES-module glue
   │                      • mpt_crypto.wasm the single shared module both glues wrap
   ├─ test-wasm.sh    → (1) compiles the crypto test suite to wasm, runs it under
   │                    Node via ctest; (2) smoke-tests BOTH shipped glues     ← gate
   └─ bundle + upload → mpt-crypto-wasm-bundle  (js + mjs + wasm)
                                        │
   build.yml `release` job (on tag) ────┘
        needs [build-and-test, native-binaries, wasm]
        → attaches mpt-crypto-wasm-<tag>.tar.gz to the GitHub release (next to the native bundle)
```

WASM is a single portable target, so there's no OS×arch matrix — one wasm32 module runs in every browser and in Node/Deno on any platform.

## Dual glue: one wasm, CommonJS + ES module
The wasm module is consumed by xrpl.js, which ships as a **dual CJS+ESM package**. To serve both without shipping the wasm twice, `build-wasm.sh` links the glue **twice from the identical object files**, both wrapping the **same** `mpt_crypto.wasm`:

| Output | emcc flags | Consumer |
|---|---|---|
| `mpt_crypto.js` | `MODULARIZE` (CommonJS) | Node / Jest (`require`) — reads the `.wasm` off disk |
| `mpt_crypto.mjs` | `-sEXPORT_ES6=1` (ES module) | bundlers / browsers (`import`) — locates the wasm via `new URL('mpt_crypto.wasm', import.meta.url)`, which webpack/rollup turn into an emitted asset |

The ESM glue is what lets Confidential MPT run in the browser: the CommonJS glue statically `require`s `node:fs`/`node:crypto` and can't be bundled, whereas the `new URL(import.meta.url)` form makes bundlers emit the wasm as a fetchable asset. Both glues are byte-for-byte the same ABI over the same module — shipping the trio together keeps the glue and wasm in lockstep.

## File by file
| File | Role |
|---|---|
| `.github/scripts/build-wasm.sh` | **Builds the module.** `emcc` link that statically bundles secp256k1 + a stripped OpenSSL, then emits **both** glues (`mpt_crypto.js` MODULARIZE + `mpt_crypto.mjs` EXPORT_ES6) over the same `mpt_crypto.wasm`. Reads dep versions from `conan.lock`; verifies dependency integrity (pinned secp256k1 commit + OpenSSL tarball SHA-256); forces static secp256k1 (`-DBUILD_SHARED_LIBS=OFF`); exports only the symbols consumers use. |
| `.github/scripts/test-wasm.sh` | **Validates it.** (1) Compiles the C crypto test suite to wasm32 and runs each test under Node via `ctest`, reusing the deps `build-wasm.sh` just built. (2) Smoke-tests **both shipped glues** the way consumers load them (`require` the `.js`, `import` the `.mjs`): instantiate, init the secp256k1 context, then `malloc` + run one export + read `HEAPU8` — so a bad `-s` flag or ABI break fails here, not downstream. |
| `.github/workflows/build-wasm.yml` | **The CI workflow.** Reusable (`workflow_call`), single ubuntu job, no matrix. Runs the two scripts, bundles the output (js + mjs + wasm), uploads `mpt-crypto-wasm-bundle`. |
| `.github/workflows/build.yml` | **Wires it in.** Adds a `wasm` job beside `native-binaries`, adds it to `release.needs`, and attaches the wasm tarball on tag push. |
| `.gitignore` | Ignores the emscripten build outputs (`emcc_build/`, `emcc_out/`). |

## Dependency integrity
The native build gets integrity from Conan (`conan.lock` revisions + source SHA-256). This WASM path fetches secp256k1 (git tag) and OpenSSL (release tarball) directly, so it verifies them explicitly to match that guarantee:
- **secp256k1** — the checked-out commit is verified against a pinned SHA (a git tag is mutable; the commit is not).
- **OpenSSL** — the tarball's SHA-256 is verified against a pinned hash before extraction.

## How it's tested
`test-wasm.sh` runs two layers, both gating the `release` job:
1. **Crypto** — compiles mpt-crypto's C crypto test suite to wasm32 and runs all 11 tests under Node via `ctest`.
2. **Glue / ABI** — loads each shipped glue the consumer way (`require` the `.js`, `import` the `.mjs`) and exercises the marshalling contract end to end (secp256k1 context init + `malloc` / `mpt_generate_blinding_factor` / `HEAPU8`).

So a wasm build whose crypto misbehaves — or whose glue/ABI a bad emcc flag has broken — can't ship.
