### PR TITLE
ci: prevent slow sanitizer builds from silently skipping releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container != '' && fromJson(matrix.container) || null }}
-    timeout-minutes: 10
+    # Sanitizer builds (asan/tsan/ubsan) on the contended self-hosted runners
+    # legitimately exceed 10 minutes; a too-tight cap here fails build-and-test,
+    # and because `release` needs it, a tag push then silently skips publishing.
+    timeout-minutes: 30
 
     env:
       BUILD_DIR: build
@@ -154,3 +157,26 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --generate-notes \
             $PRERELEASE_FLAG
+
+  # On tag push only: fail loudly if the release did NOT publish. `release` is
+  # gated on build-and-test/native-binaries/wasm, so any failure there skips it
+  # — and a *skipped* release is otherwise silent (the tag exists, no artifacts
+  # attached, no red X). This guard runs regardless of upstream results and
+  # turns that silent skip into a visible failure with the culprit named.
+  release-guard:
+    name: Verify release published
+    if: ${{ always() && github.ref_type == 'tag' }}
+    needs: [build-and-test, native-binaries, wasm, release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert the release job succeeded
+        run: |
+          if [[ "${{ needs.release.result }}" != "success" ]]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} did not publish a release" \
+                 "(release job: ${{ needs.release.result }})."
+            echo "Upstream results — build-and-test: ${{ needs.build-and-test.result }}," \
+                 "native-binaries: ${{ needs.native-binaries.result }}," \
+                 "wasm: ${{ needs.wasm.result }}."
+            exit 1
+          fi
+          echo "Release for ${GITHUB_REF_NAME} published successfully."


### PR DESCRIPTION
## Summary

Raises the `build-and-test` job timeout and adds a guard so a tagged release
can never silently fail to publish. Two small changes to `build.yml`:

1. `timeout-minutes: 10 → 30` on `build-and-test`.
2. A new `release-guard` job that fails loudly on a tag push if the `release`
   job did not publish.

## Motivation

On the post-merge run to `main`
([run 31718861146](https://github.com/XRPLF/mpt-crypto/actions/runs/31718861146)),
many `build-and-test` legs failed with *"exceeded the maximum execution time of
10m0s"* — the sanitizer builds (asan/tsan/ubsan) on the contended self-hosted
runners legitimately need more than 10 minutes (they hit exactly ~10m05s, i.e.
capped rather than hung). Every artifact-producing job (all six native shared
libraries + WASM) succeeded.

The concern this surfaces is the **release path**:

```yaml
release:
  if: github.ref_type == 'tag'
  needs: [build-and-test, native-binaries, wasm]
