### PR TITLE
ci: Export secp256k1 elgamal subtract and add for WASM

### DIFF
--- a/.github/scripts/build-wasm.sh
+++ b/.github/scripts/build-wasm.sh
@@ -301,6 +301,13 @@ EXPORTS="${EXPORTS},_mpt_verify_send_range_proof"
 EXPORTS="${EXPORTS},_mpt_verify_aggregated_bulletproof"
 EXPORTS="${EXPORTS},_mpt_make_ec_pair,_mpt_serialize_ec_pair"
 EXPORTS="${EXPORTS},_mpt_compute_convert_back_remainder"
+# Homomorphic ElGamal ciphertext add/subtract (secp256k1_pubkey in/out, defined in
+# src/elgamal.c, return 1 on success). Not used by the single-transaction builders,
+# but batching multiple balance-mutating Confidential MPT transactions for one
+# (account, token) requires predicting the post-inner spending balance client-side
+# (CB_S' = CB_S -/+ the encrypted amount) so each chained proof binds to it. The TS
+# wrapper marshals bytes<->secp256k1_pubkey via _mpt_make_ec_pair/_mpt_serialize_ec_pair.
+EXPORTS="${EXPORTS},_secp256k1_elgamal_add,_secp256k1_elgamal_subtract"
 
 # Why these -s link flags (they define the JS-facing contract, so don't drop them
 # without checking the @xrplf/mpt-crypto TS wrapper):

--- a/.github/workflows/build-native-libs.yml
+++ b/.github/workflows/build-native-libs.yml
@@ -1,5 +1,5 @@
 # ──────────────────────────────────────────────────────────────────────────────
-# Build Shared Libraries
+# Build Native Libraries
 #
 # Builds the mpt-crypto C library for each supported platform in TWO forms:
 #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,13 +103,13 @@ jobs:
         run: ctest --output-on-failure
         working-directory: ${{ env.BUILD_DIR }}
 
-  # Build the shared-library bundle (per-platform .so/.dylib/.dll) by calling
-  # the reusable workflow.
+  # Build the native-library bundle (per-platform shared .so/.dylib/.dll +
+  # self-contained static .a/.lib) by calling the reusable workflow.
   native-binaries:
-    name: Build native shared libraries
+    name: Build native libraries
     permissions:
       contents: read
-    uses: ./.github/workflows/build-shared-libs.yml
+    uses: ./.github/workflows/build-native-libs.yml
 
   # Build the portable WebAssembly module (mpt_crypto.js + .mjs + .wasm) for
   # JS/TS consumers (e.g. xrpl.js) by calling the reusable workflow.


### PR DESCRIPTION
## Summary
Adds `_secp256k1_elgamal_add` / `_secp256k1_elgamal_subtract` to the WASM `EXPORTED_FUNCTIONS`. Build-script change only — no C/C++ source change, no crypto/proof-behavior change.

## Why
xrpl.js needs homomorphic ciphertext add/subtract to batch Confidential MPT (XLS-0096) txns: when two balance-mutating txns for the same `(account, token)` share a Batch, the second proof must bind to the balance the first leaves behind (`CB_S' = CB_S ∓ encAmt`), predicted client-side. The functions already exist in `src/elgamal.c` but were dead-stripped; the TS wrapper marshals via the already-exported `mpt_make_ec_pair` / `mpt_serialize_ec_pair`.

## Changes
- `build-wasm.sh`: export the two `elgamal` functions.
- Rename `build-shared-libs.yml` → `build-native-libs.yml` (+ `build.yml` refs), now that it builds static libs too.